### PR TITLE
Add OneDrive Storage Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ target/
 nazurin.json
 firebase.json
 temp/
+
+# Filesystem file
+.DS_Store

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,3 @@ cloudant
 mega.py
 # Google Drive:
 PyDrive2
-# Microsoft Authentication Library and Graph Api
-msal
-microsoftgraph-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,6 @@ cloudant
 mega.py
 # Google Drive:
 PyDrive2
+# Microsoft Authentication Library and Graph Api
+msal
+microsoftgraph-python

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -1,21 +1,34 @@
 from os import environ
+from config import NAZURIN_DATA
+from database import Database
 from microsoftgraph.client import Client
+import msal
 
 OD_FOLDER = environ.get('OD_FOLDER','Pictures')
 OD_CLIENT = environ.get('OD_CLIENT')
 OD_SECRET = environ.get('OD_SECRET')
 OD_RD_URL = environ.get('OD_RD_URL',r'http://localhost')
-OD_RF_TOKEN = environ.get('OD_RF_TOKEN')
+OD_RF_TOKEN = environ.get('OD_RF_TOKEN',None)
+
+OD_DOCUMENT = 'onedrive'
 
 class OneDrive(object):
     """Onedrive driver."""
+    api = Client(OD_CLIENT,OD_SECRET)
+    db = Database().driver()
+    collection = db.collection(NAZURIN_DATA)
+    document = collection.document(OD_DOCUMENT)
+    initialize = False
+    refresh_token =None
+
     folder_id = None
 
-    def __init__(self): # To find the folder and its id
+    def __init__(self): 
+        self.auth()
+        # To find the folder and its id
         if not self.folder_id:
-            od = self.auth()
             # seek
-            folders = dict(od.drive_root_children_items())
+            folders = dict(self.api.drive_root_children_items())
             folders = folders.get('value')
             for folder in folders:
                 if folder['name'] == OD_FOLDER:
@@ -25,30 +38,35 @@ class OneDrive(object):
                 # create a folder
                 url = 'https://graph.microsoft.com/v1.0/me/drive/root/children'
                 body = {"name": "Pictures","folder": {}}
-                result = od._post(url,json=body)
+                result = self.api._post(url,json=body)
                 if result.get('id'):
                     self.folder_id = result['id']
 
     def auth(self):
-        try:
-            od = Client(OD_CLIENT,OD_SECRET)
-            token = od.refresh_token(OD_RD_URL,OD_RF_TOKEN)
-            token = od.set_token(token)
-        except:
-            od = None
-        return od
+        refresh_token = self.document.get()
+        if not refresh_token:
+            if OD_RF_TOKEN:
+                refresh_token=OD_RF_TOKEN
+            else:
+                return
+        token = self.api.refresh_token(OD_RD_URL,refresh_token)
+        token = self.api.set_token(token)
+
+        # Update refresh token
+        auth_api = msal.ClientApplication(OD_CLIENT,OD_SECRET)
+        refresh_token = auth_api.acquire_token_by_refresh_token(refresh_token,["https://graph.microsoft.com/.default"])
+        self.document.update(refresh_token)
+
         
-    def update_token(self):
-        pass
     def store(self, files):
-        od = self.auth()
+        self.auth()
         for item in files:
             # decorate upload api url
             url = 'https://graph.microsoft.com/v1.0/me/drive/items/{parent_id}:/{filename}:/content'.format(parent_id=self.folder_id,filename=item.name)
             # for _put() method create a dict
             file = dict()
             file[item.name] = open(item.path)
-            od._put(url,files=file)
+            self.api._put(url,files=file)
 
 
         

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -36,7 +36,7 @@ class OneDrive(object):
             # create file for upload
             create_file_url = 'https://graph.microsoft.com/v1.0/me/drive/items/{parent_id}/children'.format(
                 parent_id=self.folder_id)
-            body = {"name": item.name, "file": {}}
+            body = {"name": item.name, "file": {}, "@microsoft.graph.conflictBehavior": "replace"}
             response = self._request('POST', create_file_url, json=body)
             # create session for upload
             create_session_url = 'https://graph.microsoft.com/v1.0/me/drive/items/{item_id}/createUploadSession'.format(

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -55,7 +55,10 @@ class OneDrive(object):
         # Update refresh token
         auth_api = msal.ClientApplication(OD_CLIENT,OD_SECRET)
         refresh_token = auth_api.acquire_token_by_refresh_token(refresh_token,["https://graph.microsoft.com/.default"])
-        self.document.update(refresh_token)
+        if self.initialize:
+            self.collection.insert(OD_DOCUMENT,refresh_token)
+        else:
+            self.document.update(refresh_token)
         logger.info('OneDrive refresh token cached')
         
     def store(self, files):

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -71,7 +71,7 @@ class OneDrive(object):
             # decorate upload api url
             url = 'https://graph.microsoft.com/v1.0/me/drive/items/{parent_id}:/{filename}:/content'.format(parent_id=self.folder_id,filename=item.name)
             file = open(item.path,mode='rb')
-            self.api._put(url,files=(item.name,file))
+            self.api._put(url,files={'file':file})
             file.close()
 
 

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -70,10 +70,10 @@ class OneDrive(object):
         for item in files:
             # decorate upload api url
             url = 'https://graph.microsoft.com/v1.0/me/drive/items/{parent_id}:/{filename}:/content'.format(parent_id=self.folder_id,filename=item.name)
-            # for _put() method create a dict
-            file = dict()
-            file[item.name] = open(item.path,mode='rb')
-            self.api._put(url,files=file)
+            file = open(item.path,mode='rb')
+            self.api._put(url,files=(item.name,file))
+            file.close()
+
 
 
         

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -1,104 +1,137 @@
+import time
 from os import environ
+
+import requests
+
 from config import NAZURIN_DATA, STORAGE_DIR
 from database import Database
 from utils import logger
-import requests
 
 OD_FOLDER = STORAGE_DIR
 OD_CLIENT = environ.get('OD_CLIENT')
 OD_SECRET = environ.get('OD_SECRET')
-OD_RF_TOKEN = environ.get('OD_RF_TOKEN', None) # Refresh token for the first auth
-
+OD_RF_TOKEN = environ.get('OD_RF_TOKEN',
+                          None)  # Refresh token for first-time auth
 OD_DOCUMENT = 'onedrive'
-
-AUTH_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
 
 class OneDrive(object):
     """Onedrive driver."""
     db = Database().driver()
     collection = db.collection(NAZURIN_DATA)
     document = collection.document(OD_DOCUMENT)
-    initialize = False
 
+    access_token = None
+    refresh_token = None
+    expires_at = 0
     folder_id = None
 
-    def __init__(self):
-        self.auth()
-        # To find the folder and its id
-        url = 'https://graph.microsoft.com/v1.0/me/drive/root/children' # Here only list the root's children
+    def store(self, files):
+        # https://docs.microsoft.com/zh-cn/graph/api/driveitem-put-content?view=graph-rest-1.0&tabs=http
+        # https://docs.microsoft.com/zh-cn/graph/api/driveitem-createuploadsession?view=graph-rest-1.0
+        self.requireAuth()
+        if not self.folder_id:
+            self.getDestination()
+
+        for item in files:
+            # decorate upload api url
+            url = 'https://graph.microsoft.com/v1.0/me/drive/items/{parent_id}:/{filename}:/content'.format(
+                parent_id=self.folder_id, filename=item.name)
+            with open(item.path, mode='rb') as file:
+                self._request('PUT', url, data=file)
+
+    def findFolder(self, name):
+        self.requireAuth()
         # https://docs.microsoft.com/zh-cn/graph/api/driveitem-list-children?view=graph-rest-1.0&tabs=http
+        url = 'https://graph.microsoft.com/v1.0/me/drive/root/children'
         folders = dict(self._request('GET', url))
         folders = folders.get('value')
         for folder in folders:
-            if folder['name'] == OD_FOLDER:
-                self.folder_id = folder['id']
-                break
-        else:
-            # create a folder
-            body = {"name": OD_FOLDER, "folder": {}}
-            result = self._request('POST', url, json=body)
-            if result.get('id'):
-                self.folder_id = result['id']
+            if folder['name'] == name:
+                return folder['id']
+        return None
 
-    def store(self, files):
-        self.auth()
-        for item in files:
-            # decorate upload api url
-            url = 'https://graph.microsoft.com/v1.0/me/drive/items/{parent_id}:/{filename}:/content'.format(parent_id=self.folder_id, filename=item.name)
-            # https://docs.microsoft.com/zh-cn/graph/api/driveitem-put-content?view=graph-rest-1.0&tabs=http
-            file = open(item.path, mode='rb')
-            self._request('PUT', url, data=file)
-            file.close()
+    def createFolder(self, name):
+        self.requireAuth()
+        # https://docs.microsoft.com/zh-cn/graph/api/driveitem-post-children?view=graph-rest-1.0&tabs=http
+        url = 'https://graph.microsoft.com/v1.0/me/drive/root/children'
+        body = {"name": name, "folder": {}}
+        result = self._request('POST', url, json=body)
+        return result['id']
 
-    def auth(self):
-        # Get a refresh_token from database
-        token_dict = self.document.get()
-        if token_dict:
-            self.initialize = True # To decide whether to insert a document
-            refresh_token = token_dict['refresh_token']
-        else:
-            if OD_RF_TOKEN:
-                refresh_token = OD_RF_TOKEN
-            else:
+    def requireAuth(self):
+        # https://docs.microsoft.com/zh-cn/azure/active-directory/develop/v2-oauth2-auth-code-flow
+        if self.access_token and self.expires_at > time.time():
+            # Logged in, access_token not expired
+            return
+
+        credentials = self.document.get()
+        if credentials:
+            self.refresh_token = credentials['refresh_token']
+            if 'folder_id' in credentials.keys():
+                self.folder_id = credentials['folder_id']
+            if credentials['expires_at'] > time.time():
+                self.access_token = credentials['access_token']
+                self.expires_at = credentials['expires_at']
+                logger.info('OneDrive logged in through cached tokens')
                 return
-        # Make a request
+            else:
+                self.auth()  # Refresh access_token
+        else:
+            # Database should be initialized
+            self.refresh_token = OD_RF_TOKEN
+            self.auth(initialize=True)
+
+    def auth(self, initialize=False):
+        # https://docs.microsoft.com/zh-cn/azure/active-directory/develop/v2-oauth2-auth-code-flow
+        url = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
         data = {
             'client_id': OD_CLIENT,
             'client_secret': OD_SECRET,
-            # 'redirect_url': OD_RD_URL,
-            'refresh_token': refresh_token,
+            'refresh_token': self.refresh_token,
             'grant_type': 'refresh_token'
         }
-        response = requests.post(AUTH_URL, data=data)
+        response = requests.post(url, data=data)
         response = self._parse(response)
-        if response.get('access_token'):
-            # Set access token
-            self.token = response['access_token']
+        self.access_token = response['access_token']
+        self.refresh_token = response['refresh_token']
+        self.expires_at = time.time() + response['expires_in']
+        credentials = {
+            'access_token': response['access_token'],
+            'refresh_token': response['refresh_token'],
+            'expires_at': self.expires_at
+        }
+        if initialize:
+            self.collection.insert(OD_DOCUMENT, credentials)
             logger.info('OneDrive logged in')
-            # Update refresh token
-            refresh_token = response['refresh_token']
-            if self.initialize:
-                self.document.update({'refresh_token': refresh_token})
-            else:
-                self.collection.insert(OD_DOCUMENT, {'refresh_token': refresh_token})
-                self.initialize = True
-            logger.info('OneDrive refresh token cached')
+        else:
+            self.document.update(credentials)
+            logger.info('OneDrive access token updated')
+
+    def getDestination(self):
+        # Try to find the folder and its id
+        self.folder_id = self.findFolder(OD_FOLDER)
+        # Not found, create a new folder
+        if not self.folder_id:
+            self.folder_id = self.createFolder(OD_FOLDER)
+        self.document.update({'folder_id': self.folder_id})
+        logger.info('OneDrive folder ID cached')
 
     def _request(self, method, url, headers=None, **kwargs):
         # make a request with access token
         _header = {
             'Accept': 'application/json',
-            'Authorization': 'Bearer ' + self.token,
+            'Authorization': 'Bearer ' + self.access_token,
             'Content-Type': 'image/jpeg'
         }
         if headers:
             _header.update(headers)
         if 'files' not in kwargs:
             _header['Content-Type'] = 'application/json'
-        return self._parse(requests.request(method, url, headers=_header, **kwargs))
+        response = requests.request(method, url, headers=_header, **kwargs)
+        response.raise_for_status()
+        return self._parse(response)
 
     def _parse(self, response):
-        # stylish response
         if 'application/json' in response.headers['Content-Type']:
             r = response.json()
         else:

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -55,6 +55,7 @@ class OneDrive(object):
         # Update refresh token
         auth_api = msal.ClientApplication(OD_CLIENT,OD_SECRET)
         refresh_token = auth_api.acquire_token_by_refresh_token(refresh_token,["https://graph.microsoft.com/.default"])
+        refresh_token = refresh_token["refresh_token"]
         if self.initialize:
             self.document.update(refresh_token)
         else:

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -63,7 +63,7 @@ class OneDrive(object):
             self.collection.insert(OD_DOCUMENT, refresh_token)
             self.initialize = True
         logger.info('OneDrive refresh token cached')
-        
+
     def store(self, files):
         self.auth()
         for item in files:

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -2,8 +2,6 @@ from os import environ
 from config import NAZURIN_DATA, STORAGE_DIR
 from database import Database
 from utils import logger
-from microsoftgraph.client import Client
-import msal
 import requests
 
 OD_FOLDER = STORAGE_DIR
@@ -18,7 +16,6 @@ TOKEN_ENDPOINT = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
 
 class OneDrive(object):
     """Onedrive driver."""
-    api = Client(OD_CLIENT, OD_SECRET)
     db = Database().driver()
     collection = db.collection(NAZURIN_DATA)
     document = collection.document(OD_DOCUMENT)
@@ -30,7 +27,8 @@ class OneDrive(object):
     def __init__(self):
         self.auth()
         # To find the folder and its id
-        folders = dict(self.api.drive_root_children_items())
+        url = 'https://graph.microsoft.com/v1.0/me/drive/root/children'
+        folders = dict(self._request('GET', url))
         folders = folders.get('value')
         for folder in folders:
             if folder['name'] == OD_FOLDER:
@@ -38,13 +36,22 @@ class OneDrive(object):
                 break
         else:
             # create a folder
-            url = 'https://graph.microsoft.com/v1.0/me/drive/root/children'
             body = {"name": OD_FOLDER, "folder": {}}
-            result = self.api._post(url, json=body)
+            result = self._request('POST', url, json=body)
             if result.get('id'):
                 self.folder_id = result['id']
 
+    def store(self, files):
+        self.auth()
+        for item in files:
+            # decorate upload api url
+            url = 'https://graph.microsoft.com/v1.0/me/drive/items/{parent_id}:/{filename}:/content'.format(parent_id=self.folder_id, filename=item.name)
+            file = open(item.path, mode='rb')
+            self._request('PUT', url, files={'file':file})
+            file.close()
+
     def auth(self):
+        # Get a refresh_token
         token_dict = self.document.get()
         if token_dict:
             refresh_token = token_dict['refresh_token']
@@ -53,41 +60,43 @@ class OneDrive(object):
                 refresh_token = OD_RF_TOKEN
             else:
                 return
-        token = self.api.refresh_token(OD_RD_URL, refresh_token)
-        token = self.api.set_token(token)
-        logger.info('OneDrive logged in')
-
-        # Update refresh token
-        auth_api = msal.ClientApplication(OD_CLIENT, OD_SECRET)
-        refresh_token = auth_api.acquire_token_by_refresh_token(refresh_token, ["https://graph.microsoft.com/.default"])
-        if self.initialize:
-            self.document.update(refresh_token)
-        else:
-            self.collection.insert(OD_DOCUMENT, refresh_token)
-            self.initialize = True
-        logger.info('OneDrive refresh token cached')
-
-    def store(self, files):
-        self.auth()
-        for item in files:
-            # decorate upload api url
-            url = 'https://graph.microsoft.com/v1.0/me/drive/items/{parent_id}:/{filename}:/content'.format(parent_id=self.folder_id, filename=item.name)
-            file = open(item.path, mode='rb')
-            self.api._put(url, files={'file':file})
-            file.close()
-
-    def get_token(self, redirect_url, refresh_token):
+        # Make a request
         data = {
             'client_id': OD_CLIENT,
             'client_secret': OD_SECRET,
             'redirect_url': OD_RD_URL,
-            'refresh_token': OD_RF_TOKEN,
+            'refresh_token': refresh_token,
             'grant_type': 'refresh_token'
         }
         response = requests.post(TOKEN_ENDPOINT, data=data)
+        response = self._parse(response)
+        # error handler place
+        if response.get('access_token'):
+            self.token = response['access_token']
+            logger.info('OneDrive logged in')
+            # Update refresh token
+            refresh_token = response['refresh_token']
+            if self.initialize:
+                self.document.update(refresh_token)
+            else:
+                self.collection.insert(OD_DOCUMENT, refresh_token)
+                self.initialize = True
+            logger.info('OneDrive refresh token cached')
+
+    def _request(self, method, url, headers=None, **kwargs):
+        _header = {
+            'Accept': 'application/json',
+            'Authorization': 'Bearer ' + self.token
+        }
+        if headers:
+            _header.update(headers)
+        if 'files' not in kwargs:
+            _header['Content-Type'] = 'application/json'
+        return self._parse(requests.request(method, url, headers=_header, **kwargs))
+
+    def _parse(response):
         if 'application/json' in response.headers['Content-Type']:
             r = response.json()
         else:
             r = response.content
-        # error handler place
         return r

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -56,9 +56,9 @@ class OneDrive(object):
         auth_api = msal.ClientApplication(OD_CLIENT,OD_SECRET)
         refresh_token = auth_api.acquire_token_by_refresh_token(refresh_token,["https://graph.microsoft.com/.default"])
         if self.initialize:
-            self.collection.insert(OD_DOCUMENT,refresh_token)
-        else:
             self.document.update(refresh_token)
+        else:
+            self.collection.insert(OD_DOCUMENT,refresh_token)
         logger.info('OneDrive refresh token cached')
         
     def store(self, files):

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -45,10 +45,8 @@ class OneDrive(object):
         for item in files:
             # decorate upload api url
             url = 'https://graph.microsoft.com/v1.0/me/drive/items/{parent_id}:/{filename}:/content'.format(parent_id=self.folder_id, filename=item.name)
-            print(item.path)
-            print(item.name)
             file = open(item.path, mode='rb')
-            self._request('PUT', url, files={'file':file})
+            self._request('PUT', url, data=file)
             file.close()
 
     def auth(self):

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -7,12 +7,12 @@ import requests
 OD_FOLDER = STORAGE_DIR
 OD_CLIENT = environ.get('OD_CLIENT')
 OD_SECRET = environ.get('OD_SECRET')
-OD_RD_URL = environ.get('OD_RD_URL', r'http://localhost/getAToken') # Application redirect_url
+# OD_RD_URL = environ.get('OD_RD_URL', r'http://localhost/getAToken') # Application redirect_url
 OD_RF_TOKEN = environ.get('OD_RF_TOKEN', None) # Refresh token for the first auth
 
 OD_DOCUMENT = 'onedrive'
 
-TOKEN_ENDPOINT = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
+AUTH_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
 
 class OneDrive(object):
     """Onedrive driver."""
@@ -64,11 +64,11 @@ class OneDrive(object):
         data = {
             'client_id': OD_CLIENT,
             'client_secret': OD_SECRET,
-            'redirect_url': OD_RD_URL,
+            # 'redirect_url': OD_RD_URL,
             'refresh_token': refresh_token,
             'grant_type': 'refresh_token'
         }
-        response = requests.post(TOKEN_ENDPOINT, data=data)
+        response = requests.post(AUTH_URL, data=data)
         response = self._parse(response)
         # error handler place
         if response.get('access_token'):

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -15,7 +15,7 @@ OD_RF_TOKEN = environ.get('OD_RF_TOKEN',
 OD_DOCUMENT = 'onedrive'
 
 class OneDrive(object):
-    """Onedrive driver."""
+    """OneDrive driver."""
     db = Database().driver()
     collection = db.collection(NAZURIN_DATA)
     document = collection.document(OD_DOCUMENT)
@@ -72,7 +72,7 @@ class OneDrive(object):
                 return folder['id']
         return None
 
-    def createFolder(self, name):
+    def createFolder(self, name: str):
         self.requireAuth()
         # https://docs.microsoft.com/zh-cn/graph/api/driveitem-post-children?view=graph-rest-1.0&tabs=http
         url = 'https://graph.microsoft.com/v1.0/me/drive/root/children'
@@ -95,7 +95,6 @@ class OneDrive(object):
                 self.access_token = credentials['access_token']
                 self.expires_at = credentials['expires_at']
                 logger.info('OneDrive logged in through cached tokens')
-                return
             else:
                 self.auth()  # Refresh access_token
         else:

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -86,7 +86,8 @@ class OneDrive(object):
     def _request(self, method, url, headers=None, **kwargs):
         _header = {
             'Accept': 'application/json',
-            'Authorization': 'Bearer ' + self.token
+            'Authorization': 'Bearer ' + self.token,
+            'Content-Type': 'image/jpeg'
         }
         if headers:
             _header.update(headers)

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -72,7 +72,7 @@ class OneDrive(object):
             url = 'https://graph.microsoft.com/v1.0/me/drive/items/{parent_id}:/{filename}:/content'.format(parent_id=self.folder_id,filename=item.name)
             # for _put() method create a dict
             file = dict()
-            file[item.name] = open(item.path)
+            file[item.name] = open(item.path,mode='rb')
             self.api._put(url,files=file)
 
 

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -1,0 +1,55 @@
+from os import environ
+from microsoftgraph.client import Client
+
+OD_FOLDER = environ.get('OD_FOLDER','Pictures')
+OD_CLIENT = environ.get('OD_CLIENT')
+OD_SECRET = environ.get('OD_SECRET')
+OD_RD_URL = environ.get('OD_RD_URL',r'http://localhost')
+OD_RF_TOKEN = environ.get('OD_RF_TOKEN')
+
+class OneDrive(object):
+    """Onedrive driver."""
+    folder_id = None
+
+    def __init__(self): # To find the folder and its id
+        if not self.folder_id:
+            od = self.auth()
+            # seek
+            folders = dict(od.drive_root_children_items())
+            folders = folders.get('value')
+            for folder in folders:
+                if folder['name'] == OD_FOLDER:
+                    self.folder_id = folder['id']
+                    break
+            else:
+                # create a folder
+                url = 'https://graph.microsoft.com/v1.0/me/drive/root/children'
+                body = {"name": "Pictures","folder": {}}
+                result = od._post(url,json=body)
+                if result.get('id'):
+                    self.folder_id = result['id']
+
+    def auth(self):
+        try:
+            od = Client(OD_CLIENT,OD_SECRET)
+            token = od.refresh_token(OD_RD_URL,OD_RF_TOKEN)
+            token = od.set_token(token)
+        except:
+            od = None
+        return od
+        
+    def update_token(self):
+        pass
+    def store(self, files):
+        od = self.auth()
+        for item in files:
+            # decorate upload api url
+            url = 'https://graph.microsoft.com/v1.0/me/drive/items/{parent_id}:/{filename}:/content'.format(parent_id=self.folder_id,filename=item.name)
+            # for _put() method create a dict
+            file = dict()
+            file[item.name] = open(item.path)
+            od._put(url,files=file)
+
+
+        
+

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -4,6 +4,7 @@ from database import Database
 from utils import logger
 from microsoftgraph.client import Client
 import msal
+import requests
 
 OD_FOLDER = STORAGE_DIR
 OD_CLIENT = environ.get('OD_CLIENT')
@@ -12,6 +13,8 @@ OD_RD_URL = environ.get('OD_RD_URL', r'http://localhost/getAToken') # Applicatio
 OD_RF_TOKEN = environ.get('OD_RF_TOKEN', None) # Refresh token for the first auth
 
 OD_DOCUMENT = 'onedrive'
+
+TOKEN_ENDPOINT = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
 
 class OneDrive(object):
     """Onedrive driver."""
@@ -72,3 +75,19 @@ class OneDrive(object):
             file = open(item.path, mode='rb')
             self.api._put(url, files={'file':file})
             file.close()
+
+    def get_token(self, redirect_url, refresh_token):
+        data = {
+            'client_id': OD_CLIENT,
+            'client_secret': OD_SECRET,
+            'redirect_url': OD_RD_URL,
+            'refresh_token': OD_RF_TOKEN,
+            'grant_type': 'refresh_token'
+        }
+        response = requests.post(TOKEN_ENDPOINT, data=data)
+        if 'application/json' in response.headers['Content-Type']:
+            r = response.json()
+        else:
+            r = response.content
+        # error handler place
+        return r

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -25,31 +25,41 @@ class OneDrive(object):
     expires_at = 0
     folder_id = None
 
-    def store(self, files):
-        # https://docs.microsoft.com/zh-cn/graph/api/driveitem-put-content?view=graph-rest-1.0&tabs=http
+    def upload(self, file):
         # https://docs.microsoft.com/zh-cn/graph/api/driveitem-createuploadsession?view=graph-rest-1.0
+        file.size = path.getsize(file.path)
+        # create drive item
+        create_file_url = 'https://graph.microsoft.com/v1.0/me/drive/items/{parent_id}/children'.format(
+            parent_id=self.folder_id)
+        body = {
+            "name": file.name,
+            "size": file.size,
+            "file": {},
+            "@microsoft.graph.conflictBehavior": "replace"
+        }
+        response = self._request('POST', create_file_url, json=body)
+        # create upload session
+        create_session_url = 'https://graph.microsoft.com/v1.0/me/drive/items/{item_id}/createUploadSession'.format(
+            item_id=response['id'])
+        response = self._request('POST', create_session_url)
+        # upload
+        header = {
+            'Content-Range':
+            'bytes 0-{end}/{size}'.format(end=file.size - 1, size=file.size)
+        }
+        with open(file.path, mode='rb') as data:
+            self._request('PUT',
+                          response['uploadUrl'],
+                          headers=header,
+                          data=data)
+
+    def store(self, files):
         self.requireAuth()
         if not self.folder_id:
             self.getDestination()
 
         for item in files:
-            # create file for upload
-            create_file_url = 'https://graph.microsoft.com/v1.0/me/drive/items/{parent_id}/children'.format(
-                parent_id=self.folder_id)
-            body = {"name": item.name, "file": {}, "@microsoft.graph.conflictBehavior": "replace"}
-            response = self._request('POST', create_file_url, json=body)
-            # create session for upload
-            create_session_url = 'https://graph.microsoft.com/v1.0/me/drive/items/{item_id}/createUploadSession'.format(
-                item_id=response['id'])
-            response = self._request('POST', create_session_url)
-            # upload
-            if response.get('uploadUrl'):
-                item_size = path.getsize(item.path)
-                header = {
-                    'Content-Range': 'bytes 0-{end}/{size}'.format(end=item_size-1, size=item_size)
-                }
-                with open(item.path, mode='rb') as file:
-                    self._request('PUT', response['uploadUrl'], headers=header, data=file)
+            self.upload(item)
 
     def findFolder(self, name):
         self.requireAuth()

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -53,6 +53,7 @@ class OneDrive(object):
         # Get a refresh_token
         token_dict = self.document.get()
         if token_dict:
+            self.initialize = True
             refresh_token = token_dict['refresh_token']
         else:
             if OD_RF_TOKEN:
@@ -76,9 +77,9 @@ class OneDrive(object):
             # Update refresh token
             refresh_token = response['refresh_token']
             if self.initialize:
-                self.document.update(refresh_token)
+                self.document.update({'refresh_token': refresh_token})
             else:
-                self.collection.insert(OD_DOCUMENT, refresh_token)
+                self.collection.insert(OD_DOCUMENT, {'refresh_token': refresh_token})
                 self.initialize = True
             logger.info('OneDrive refresh token cached')
 

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -133,11 +133,10 @@ class OneDrive(object):
         _header = {
             'Accept': 'application/json',
             'Authorization': 'Bearer ' + self.access_token,
-            'Content-Type': 'image/jpeg'
         }
         if headers:
             _header.update(headers)
-        if 'files' not in kwargs:
+        if 'data' not in kwargs:
             _header['Content-Type'] = 'application/json'
         response = requests.request(method, url, headers=_header, **kwargs)
         response.raise_for_status()

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -24,7 +24,7 @@ class OneDrive(object):
 
     folder_id = None
 
-    def __init__(self): 
+    def __init__(self):
         self.auth()
         # To find the folder and its id
         folders = dict(self.api.drive_root_children_items())
@@ -63,7 +63,7 @@ class OneDrive(object):
             self.collection.insert(OD_DOCUMENT, refresh_token)
             self.initialize = True
         logger.info('OneDrive refresh token cached')
-        
+                
     def store(self, files):
         self.auth()
         for item in files:
@@ -72,8 +72,3 @@ class OneDrive(object):
             file = open(item.path, mode='rb')
             self.api._put(url, files={'file':file})
             file.close()
-
-
-
-        
-

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -45,6 +45,8 @@ class OneDrive(object):
         for item in files:
             # decorate upload api url
             url = 'https://graph.microsoft.com/v1.0/me/drive/items/{parent_id}:/{filename}:/content'.format(parent_id=self.folder_id, filename=item.name)
+            print(item.path)
+            print(item.name)
             file = open(item.path, mode='rb')
             self._request('PUT', url, files={'file':file})
             file.close()

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -1,15 +1,15 @@
 from os import environ
-from config import NAZURIN_DATA
+from config import NAZURIN_DATA,STORAGE_DIR
 from database import Database
 from utils import logger
 from microsoftgraph.client import Client
 import msal
 
-OD_FOLDER = environ.get('OD_FOLDER','Pictures')
+OD_FOLDER = STORAGE_DIR
 OD_CLIENT = environ.get('OD_CLIENT')
 OD_SECRET = environ.get('OD_SECRET')
-OD_RD_URL = environ.get('OD_RD_URL',r'http://localhost/get_token')
-OD_RF_TOKEN = environ.get('OD_RF_TOKEN',None)
+OD_RD_URL = environ.get('OD_RD_URL',r'http://localhost/getAToken') # Application redirect_url
+OD_RF_TOKEN = environ.get('OD_RF_TOKEN',None) # Refresh token for the first auth
 
 OD_DOCUMENT = 'onedrive'
 
@@ -20,7 +20,7 @@ class OneDrive(object):
     collection = db.collection(NAZURIN_DATA)
     document = collection.document(OD_DOCUMENT)
     initialize = False
-    refresh_token =None
+    refresh_token = None
 
     folder_id = None
 

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -20,7 +20,6 @@ class OneDrive(object):
     collection = db.collection(NAZURIN_DATA)
     document = collection.document(OD_DOCUMENT)
     initialize = False
-    refresh_token = None
 
     folder_id = None
 
@@ -94,7 +93,7 @@ class OneDrive(object):
             _header['Content-Type'] = 'application/json'
         return self._parse(requests.request(method, url, headers=_header, **kwargs))
 
-    def _parse(response):
+    def _parse(self, response):
         if 'application/json' in response.headers['Content-Type']:
             r = response.json()
         else:

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -63,7 +63,7 @@ class OneDrive(object):
             self.collection.insert(OD_DOCUMENT, refresh_token)
             self.initialize = True
         logger.info('OneDrive refresh token cached')
-                
+        
     def store(self, files):
         self.auth()
         for item in files:

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -8,7 +8,7 @@ import msal
 OD_FOLDER = environ.get('OD_FOLDER','Pictures')
 OD_CLIENT = environ.get('OD_CLIENT')
 OD_SECRET = environ.get('OD_SECRET')
-OD_RD_URL = environ.get('OD_RD_URL',r'http://localhost')
+OD_RD_URL = environ.get('OD_RD_URL',r'http://localhost/get_token')
 OD_RF_TOKEN = environ.get('OD_RF_TOKEN',None)
 
 OD_DOCUMENT = 'onedrive'

--- a/storage/onedrive.py
+++ b/storage/onedrive.py
@@ -42,10 +42,13 @@ class OneDrive(object):
                 self.folder_id = result['id']
 
     def auth(self):
-        refresh_token = self.document.get()
-        if not refresh_token:
+        token_dict = self.document.get()
+        refresh_token = ''
+        if token_dict:
+            refresh_token = token_dict['refresh_token']
+        else:
             if OD_RF_TOKEN:
-                refresh_token=OD_RF_TOKEN
+                refresh_token = OD_RF_TOKEN
             else:
                 return
         token = self.api.refresh_token(OD_RD_URL,refresh_token)
@@ -55,11 +58,11 @@ class OneDrive(object):
         # Update refresh token
         auth_api = msal.ClientApplication(OD_CLIENT,OD_SECRET)
         refresh_token = auth_api.acquire_token_by_refresh_token(refresh_token,["https://graph.microsoft.com/.default"])
-        refresh_token = refresh_token["refresh_token"]
         if self.initialize:
             self.document.update(refresh_token)
         else:
             self.collection.insert(OD_DOCUMENT,refresh_token)
+            self.initialize = True
         logger.info('OneDrive refresh token cached')
         
     def store(self, files):


### PR DESCRIPTION
Use [msal](https://github.com/AzureAD/microsoft-authentication-library-for-python) and [microsoftgraph-python](https://github.com/GearPlug/microsoftgraph-python) to access OneDrive resources.

Because of the function realization limit of microsoftgraph-python, the code directly make requests by methods like `_post` provided by microsoftgraph-python. For further development the bot can directly use parts of its source code.

And if this PR can be accepted , I'm delighted to write a wiki for onedrive configuration.

---

Something unrelated to the PR:

这是我第一次交PR,有什么问题还请包涵

在给自己搭个bot的时候找到这个项目,觉得很厉害,因为自己有微软的E5订阅,于是想给项目写一下OneDrive的存储

自己是Python新手,代码风格是“沿袭”大大的

祝新年快乐
