### PR TITLE
Fix module-not-found if deploying on the server

### DIFF
--- a/nazurin/__main__.py
+++ b/nazurin/__main__.py
@@ -6,6 +6,11 @@ from aiogram.dispatcher.filters import IDFilter
 from aiogram.types import ChatActions, Message, Update
 from aiogram.utils.exceptions import TelegramAPIError
 
+import sys
+import os
+path = os.path.dirname(sys.modules[__name__].__file__)
+path = os.path.join(path, '..')
+sys.path.insert(0, path)
 from nazurin import config, dp
 from nazurin.utils import logger
 from nazurin.utils.decorators import chat_action


### PR DESCRIPTION
When I try to use `python -m nazurin` to run the bot, the 'nazurin not found' error pops up.

Fix it by [Using module's own objects in __main__.py](https://stackoverflow.com/questions/3411293/using-modules-own-objects-in-main-py)