### PR TITLE
Added support of Nitter sites (Twitter proxy)

### DIFF
--- a/nazurin/sites/Twitter/interface.py
+++ b/nazurin/sites/Twitter/interface.py
@@ -11,7 +11,10 @@ patterns = [
     # https://twitter.com/abcdefg/status/1234567890123456789
     # https://www.twitter.com/abcdefg/status/1234567890123456789
     # https://mobile.twitter.com/abcdefg/status/1234567890123456789
-    r'(?:mobile\.|www\.)?twitter\.com/[^.]+/status/(\d+)'
+    r'(?:mobile\.|www\.)?twitter\.com/[^.]+/status/(\d+)',
+
+    # https://nitter.anywhere.com/abcdefg/status/1234567890123456789
+    r'nitter\.[\w.]+/[^.]+/status/(\d+)'
 ]
 
 async def handle(match, **kwargs) -> Illust:


### PR DESCRIPTION
- Support [Nitter](https://github.com/zedeus/nitter) proxy sites like `https://nitter.mstdn.social`