### PR TITLE
fix: remove spaces in twitter url

### DIFF
--- a/nazurin/sites/twitter/api.py
+++ b/nazurin/sites/twitter/api.py
@@ -83,8 +83,8 @@ class Twitter:
     def build_caption(tweet) -> Caption:
         return Caption(
             {
-                "url": f"https://twitter.com/{tweet['user']['screen_name']}\
-                         /status/{tweet['id_str']}",
+                "url": f"https://twitter.com/{tweet['user']['screen_name']}"
+                       f"/status/{tweet['id_str']}",
                 "author": f"{tweet['user']['name']} #{tweet['user']['screen_name']}",
                 "text": tweet["text"],
             }

--- a/nazurin/sites/twitter/api.py
+++ b/nazurin/sites/twitter/api.py
@@ -84,7 +84,7 @@ class Twitter:
         return Caption(
             {
                 "url": f"https://twitter.com/{tweet['user']['screen_name']}"
-                       f"/status/{tweet['id_str']}",
+                + f"/status/{tweet['id_str']}",
                 "author": f"{tweet['user']['name']} #{tweet['user']['screen_name']}",
                 "text": tweet["text"],
             }


### PR DESCRIPTION
Not sure if other bugs were introduced in the commit d159b49058960b113bbff40f4c3dd95d4d5f1b26