### PR TITLE
fix: Kemono thumbnail 404 error

### DIFF
--- a/nazurin/sites/kemono/api.py
+++ b/nazurin/sites/kemono/api.py
@@ -57,7 +57,7 @@ class Kemono:
         image_index = 0
         for file in files:
             path: str = file["path"]
-            url = "https://c1.kemono.party/data" + path
+            url = "https://c1.kemono.su/data" + path
 
             # Handle non-image files
             if not self.is_image(path):
@@ -72,7 +72,7 @@ class Kemono:
             destination, filename = self.get_storage_dest(
                 post, f"{image_index} - {file['name']}", path
             )
-            thumbnail = "https://img.kemono.party/thumbnail/data" + path
+            thumbnail = "https://img.kemono.su/thumbnail/data" + path
             images.append(
                 Image(
                     filename,
@@ -120,7 +120,7 @@ class Kemono:
                 "title": post["title"],
                 "author": "#" + post["username"],
                 "url": (
-                    f"https://kemono.party/{post['service']}"
+                    f"https://kemono.su/{post['service']}"
                     f"/user/{post['user']}/post/{post['id']}"
                 ),
             }


### PR DESCRIPTION
`img.kemono.party` 所有图片都404了，不会像其它域名一样跳转到新域名

将其替换为 `img.kemono.su` 修复 Kemono 预览无法显示的问题

下载域名也替换为了 `c1.kemono.su` ，观察了一下和 `c1.kemono.party` 行为一致，会正确跳转到其他域名