### PR TITLE
docs: fix outdated docs and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,7 @@ IS_PUBLIC = false
 # ALLOW_USERNAME = 
 
 # Allowed group ID(s)
-# ALLOW_GROUP =
+# GROUP_ID =
 
 # Retry attempts
 RETRIES = 5

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # This is an example of .env configuration file
-# For more information, see https://github.com/y-young/nazurin/wiki/Configuration
+# For more information, see https://nazurin.readthedocs.io/getting-started/configuration/
 # Rename to .env after modifying the values and uncommenting corresponding lines
 
 # ---------- Required ----------

--- a/.env.example
+++ b/.env.example
@@ -222,7 +222,7 @@ PIXIV_BOOKMARK_PRIVACY = public
 # S3_SECRET_KEY =
 
 # Using SSL
-# S3_USE_SSL = True
+# S3_SECURE = True
 
 # Region
 # S3_REGION =

--- a/.env.example
+++ b/.env.example
@@ -184,9 +184,9 @@ PIXIV_BOOKMARK_PRIVACY = public
 # MONGO_URI = mongodb://localhost:27017/nazurin
 
 # ----- Cloudant -----
-# CLOUDANT_USERNAME =
+# CLOUDANT_USER =
 # CLOUDANT_APIKEY =
-# CLOUDANT_DATABASE = nazurin
+# CLOUDANT_DB = nazurin
 
 # ---------- Storage ----------
 # ----- Telegram -----

--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,18 @@ DATABASE = Local
 # Request timeout
 # TIMEOUT = 20
 
+# Chunk size when writing downloaded files, in bytes
+# DOWNLOAD_CHUNK_SIZE = 4096
+
+# Maximum number of parallel downloads
+# MAX_PARALLEL_DOWNLOAD = 5
+
+# Maximum number of parallel uploads
+# MAX_PARALLEL_UPLOAD = 5
+
+# Proxy URL for network requests, defaults to your environment
+# HTTP_PROXY = http://127.0.0.1:7890
+
 # Ignored items in image caption
 # CAPTION_IGNORE =
 

--- a/.env.example
+++ b/.env.example
@@ -36,10 +36,10 @@ DATABASE = Local
 
 # ---------- Optional ----------
 # Directory path for storage
-STORAGE_DIR = Pictures
+# STORAGE_DIR = Pictures
 
 # Whether to make this bot public
-IS_PUBLIC = false
+# IS_PUBLIC = false
 
 # If IS_PUBLIC is True, the following items will be ignored
 # Allowed user ID(s)
@@ -52,16 +52,16 @@ IS_PUBLIC = false
 # GROUP_ID =
 
 # Retry attempts
-RETRIES = 5
+# RETRIES = 5
 
 # Request timeout
-TIMEOUT = 10
+# TIMEOUT = 20
 
 # Ignored items in image caption
 # CAPTION_IGNORE =
 
 # Temporary directory cleanup interval, in days
-CLEANUP_INTERVAL = 7
+# CLEANUP_INTERVAL = 7
 
 # ----- Google services -----
 # API credential for Firebase & Google Drive
@@ -139,7 +139,7 @@ CLEANUP_INTERVAL = 7
 # PIXIV_TRANSLATION =
 
 # Bookmark privacy (public/private), optional
-PIXIV_BOOKMARK_PRIVACY = public
+# PIXIV_BOOKMARK_PRIVACY = public
 
 # File directory
 # PIXIV_FILE_PATH = Pixiv
@@ -148,9 +148,7 @@ PIXIV_BOOKMARK_PRIVACY = public
 # PIXIV_FILE_NAME = {filename} - {title} - {user[name]}({user[id]})
 
 # ----- Twitter -----
-
 # API selection, optional
-
 # TWITTER_API = web
 
 # Auth Token for web API, optional

--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,13 @@ CLEANUP_INTERVAL = 7
 # File name
 # GELBOORU_FILE_NAME = {id}
 
+# ----- Kemono -----
+# File directory
+# KEMONO_FILE_PATH = Kemono
+
+# File name
+# KEMONO_FILE_NAME = {pretty_name}
+
 # ----- Lofter -----
 # File directory
 # LOFTER_FILE_PATH = Lofter

--- a/app.json
+++ b/app.json
@@ -52,11 +52,11 @@
       "required": false
     },
     "PIXIV_TOKEN": {
-      "description": "Pixiv refresh token. See more information at https://github.com/y-young/nazurin/wiki/Pixiv .",
+      "description": "Pixiv refresh token. See more information at https://nazurin.readthedocs.io/site/pixiv/ .",
       "required": false
     },
     "WALLHAVEN_API_KEY": {
-      "description": "Wallhaven API key. See more information at https://github.com/y-young/nazurin/wiki/Wallhaven .",
+      "description": "Wallhaven API key. See more information at https://nazurin.readthedocs.io/site/wallhaven/ .",
       "required": false
     },
     "MEGA_USER": {

--- a/docs/site/kemono.zh.md
+++ b/docs/site/kemono.zh.md
@@ -6,13 +6,13 @@
 
 更多信息请查阅 [自定义存储路径和文件名](./index.zh.md/#customizing-storage-path--file-name)。
 
-### LOFTER_FILE_PATH
+### KEMONO_FILE_PATH
 
 :material-lightbulb-on: 可选，默认为 `Kemono/{service}/{username} ({user})/{title} ({id})`
 
 存储路径。
 
-### LOFTER_FILE_NAME
+### KEMONO_FILE_NAME
 
 :material-lightbulb-on: 可选，默认为 `{pretty_name}`
 

--- a/docs/site/pixiv.zh.md
+++ b/docs/site/pixiv.zh.md
@@ -38,6 +38,12 @@
 
 例如：`zh-CN`, `en-US`
 
+### PIXIV_BOOKMARK_PRIVACY
+
+:material-lightbulb-on: 可选，默认为 `public`
+
+收藏可见性，`public` 或 `private`。
+
 ## 自定义存储路径和文件名
 
 更多信息请查阅 [自定义存储路径和文件名](./index.zh.md/#customizing-storage-path--file-name)。


### PR DESCRIPTION
- docs(site/kemono): fix title in zh
  fixup: 6816404d4c58f4cb1b0ba08ea18c58957dec4a9c
- docs(site/pixiv): add PIXIV_BOOKMARK_PRIVACY in zh
  fixup: 6fe4e969dc4a4529abf5a702cc54fe1d954d9778
- fix(env.example):
  - `ALLOW_GROUP` is renamed to `GROUP_ID` in v2
  - rename CLOUDANT: USERNAME to USER, DATABASE to DB
  - rename `S3_USE_SSL` to `S3_SECURE`
  - add Kemono
  - comment out optional env
  - add missing optional env
- docs: replace github wiki with nazurin.readthedocs.io
