### PR TITLE
fix: bypass Bilibili IP risk control

### DIFF
--- a/nazurin/sites/bilibili/api.py
+++ b/nazurin/sites/bilibili/api.py
@@ -20,7 +20,9 @@ class Bilibili:
             f"https://api.bilibili.com/x/polymer/web-dynamic/v1/detail?id={dynamic_id}"
         )
         ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0"
-        async with Request(headers={"User-Agent": ua}) as request, request.get(api) as response:
+        async with Request(headers={"User-Agent": ua}) as request, request.get(
+            api
+        ) as response:
             response.raise_for_status()
             data = await response.json()
             # For some IDs, the API returns code 0 but empty content

--- a/nazurin/sites/bilibili/api.py
+++ b/nazurin/sites/bilibili/api.py
@@ -19,7 +19,8 @@ class Bilibili:
         api = (
             f"https://api.bilibili.com/x/polymer/web-dynamic/v1/detail?id={dynamic_id}"
         )
-        async with Request() as request, request.get(api) as response:
+        ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0"
+        async with Request(headers={"User-Agent": ua}) as request, request.get(api) as response:
             response.raise_for_status()
             data = await response.json()
             # For some IDs, the API returns code 0 but empty content


### PR DESCRIPTION
近日使用时发现 bilibili 对许多机房 ip 风控了返回 code -352，经测试添加一个 UA 即可通过风控
![屏幕截图 2025-02-25 011943](https://github.com/user-attachments/assets/090299b0-bf87-403c-bb64-f490779e9b8b)
