### PR TITLE
fix: bypass kemono DDG WAF and update endpoints to .cr

### DIFF
--- a/nazurin/sites/kemono/api.py
+++ b/nazurin/sites/kemono/api.py
@@ -1,7 +1,8 @@
 import os
 from datetime import datetime, timezone
+from http import HTTPStatus
 from mimetypes import guess_type
-from typing import ClassVar
+from typing import Any, ClassVar, TypeVar
 from urllib.parse import quote
 
 from nazurin.models import Caption, Illust, Image
@@ -9,14 +10,18 @@ from nazurin.models.file import File
 from nazurin.utils import Request
 from nazurin.utils.decorators import network_retry
 from nazurin.utils.exceptions import NazurinError
+from nazurin.utils.helpers import fromisoformat
 
 from .config import DESTINATION, FILENAME
 
+T = TypeVar("T")
 
-class Kemono:
+
+class KemonoRequest:
+    """Custom request class for Kemono API with built-in headers and JSON handling."""
+
     API_BASE: ClassVar[str] = "https://kemono.cr/api/v1"
-
-    HEADERS: ClassVar[dict] = {
+    HEADERS: ClassVar[dict[str, str]] = {
         "User-Agent": (
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
             "AppleWebKit/537.36 (KHTML, like Gecko) "
@@ -24,30 +29,44 @@ class Kemono:
         ),
         "Referer": "https://kemono.cr/",
         "Accept": "text/css",
-        "Accept-Language": "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7,zh-TW;q=0.6",
+        "Accept-Language": "en-US;q=1.0",
     }
+
+    async def get(
+        self,
+        path: str,
+        response_type: type[T],
+    ) -> T:
+        """Make a GET request and return the decoded JSON response.
+
+        Args:
+            path: Relative path appended to the API base URL.
+            response_type: Expected response type for generic type inference.
+        """
+        url = f"{self.API_BASE}/{path}"
+        async with (
+            Request() as session,
+            session.get(url, headers=self.HEADERS) as response,
+        ):
+            if response.status == HTTPStatus.FORBIDDEN:
+                content = await response.text()
+                raise NazurinError(f"403 Forbidden: {content[:100]}")
+            response.raise_for_status()
+            return await response.json(content_type=None)
+
+
+class Kemono:
+    _client: ClassVar[KemonoRequest] = KemonoRequest()
 
     @network_retry
     async def get_post(self, service: str, user_id: str, post_id: str) -> dict:
         """Fetch a post."""
-        api = f"{self.API_BASE}/{service}/user/{user_id}/post/{post_id}"
-        async with (
-            Request() as request,
-            request.get(api, headers=self.HEADERS) as response,
-        ):
-            if response.status == 403:  # noqa: PLR2004
-                content = await response.text()
-                raise NazurinError(f"403 Forbidden: {content[:100]}")
-
-            response.raise_for_status()
-
-            data = await response.json(content_type=None)
-
-            post = data.get("post", data)
-
-            username = await self.get_username(service, user_id)
-            post["username"] = username
-            return post
+        api = f"{service}/user/{user_id}/post/{post_id}"
+        data = await self._client.get(api, dict[str, Any])
+        post = data.get("post", data)
+        username = await self.get_username(service, user_id)
+        post["username"] = username
+        return post
 
     @network_retry
     async def get_post_revision(
@@ -58,36 +77,26 @@ class Kemono:
         revision_id: str,
     ) -> dict:
         """Fetch a post revision."""
-        api = f"{self.API_BASE}/{service}/user/{user_id}/post/{post_id}/revisions"
-        async with (
-            Request() as request,
-            request.get(api, headers=self.HEADERS) as response,
-        ):
-            response.raise_for_status()
-            revisions = await response.json(content_type=None)
-            post = None
-            for revision in revisions:
-                if str(revision["revision_id"]) == revision_id:
-                    post = revision
-                    break
-            if not post:
-                raise NazurinError("Post revision not found")
-            username = await self.get_username(service, user_id)
-            post["username"] = username
-            return post
+        api = f"{service}/user/{user_id}/post/{post_id}/revisions"
+        revisions = await self._client.get(api, list[dict[str, Any]])
+        post = None
+        for revision in revisions:
+            if str(revision["revision_id"]) == revision_id:
+                post = revision
+                break
+        if not post:
+            raise NazurinError("Post revision not found")
+        username = await self.get_username(service, user_id)
+        post["username"] = username
+        return post
 
     @network_retry
     async def get_username(self, service: str, user_id: str) -> str:
-        url = f"{self.API_BASE}/{service}/user/{user_id}/profile"
-        async with (
-            Request() as request,
-            request.get(url, headers=self.HEADERS) as response,
-        ):
-            response.raise_for_status()
-            profile = await response.json(content_type=None)
-            if isinstance(profile, list) and len(profile) > 0:
-                return profile[0].get("name", "")
-            return profile.get("name", "")
+        path = f"{service}/user/{user_id}/profile"
+        profile = await self._client.get(path, dict[str, Any])
+        if isinstance(profile, list) and len(profile) > 0:
+            return profile[0].get("name", "")
+        return profile.get("name", "")
 
     async def fetch(
         self,
@@ -102,9 +111,9 @@ class Kemono:
             post = await self.get_post(service, user_id, post_id)
         caption = self.build_caption(post)
 
-        images = []
-        download_files = []
-        files = [post["file"]] if post.get("file") else []
+        images: list[Image] = []
+        download_files: list[File] = []
+        files: list[dict[str, Any]] = [post["file"]] if post.get("file") else []
         files += post.get("attachments", [])
 
         if not files:
@@ -155,16 +164,14 @@ class Kemono:
         Format destination and filename.
         """
 
-        def parse_time(time_str):
-            # Define default time (1970-01-01)
+        def parse_time(time_str: Any) -> datetime:
+            default_time = datetime(1970, 1, 1, tzinfo=timezone.utc)
             if not time_str or not isinstance(time_str, str):
-                return datetime(1970, 1, 1, tzinfo=timezone.utc)
+                return default_time
             try:
-                return datetime.fromisoformat(time_str.replace("Z", "+00:00")).replace(
-                    tzinfo=timezone.utc
-                )
+                return fromisoformat(time_str).replace(tzinfo=timezone.utc)
             except (ValueError, TypeError):
-                return datetime(1970, 1, 1, tzinfo=timezone.utc)
+                return default_time
 
         added = parse_time(post.get("added"))
         edited = parse_time(post.get("edited") or post.get("added"))
@@ -188,7 +195,7 @@ class Kemono:
     @staticmethod
     def get_url(post: dict) -> str:
         url = (
-            f"https://kemono.su/{post['service']}/user/{post['user']}/post/{post['id']}"
+            f"https://kemono.cr/{post['service']}/user/{post['user']}/post/{post['id']}"
         )
         revision = post.get("revision_id")
         if revision:
@@ -196,7 +203,7 @@ class Kemono:
         return url
 
     @staticmethod
-    def build_caption(post) -> Caption:
+    def build_caption(post: dict[str, Any]) -> Caption:
         return Caption(
             {
                 "title": post["title"],
@@ -209,4 +216,4 @@ class Kemono:
     def is_image(path: str) -> bool:
         """Check if path is an image by mimetype."""
         mimetype = guess_type(path)[0]
-        return mimetype and mimetype.startswith("image")
+        return mimetype is not None and mimetype.startswith("image")

--- a/nazurin/sites/kemono/api.py
+++ b/nazurin/sites/kemono/api.py
@@ -17,7 +17,11 @@ class Kemono:
     API_BASE: ClassVar[str] = "https://kemono.cr/api/v1"
 
     HEADERS: ClassVar[dict] = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36",
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/145.0.0.0 Safari/537.36"
+        ),
         "Referer": "https://kemono.cr/",
         "Accept": "text/css",
         "Accept-Language": "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7,zh-TW;q=0.6",
@@ -31,7 +35,7 @@ class Kemono:
             Request() as request,
             request.get(api, headers=self.HEADERS) as response,
         ):
-            if response.status == 403:
+            if response.status == 403: # noqa: PLR2004
                 content = await response.text()
                 raise NazurinError(f"403 Forbidden: {content[:100]}")
 

--- a/nazurin/sites/kemono/api.py
+++ b/nazurin/sites/kemono/api.py
@@ -12,6 +12,7 @@ from nazurin.utils.exceptions import NazurinError
 
 from .config import DESTINATION, FILENAME
 
+
 class Kemono:
     API_BASE: ClassVar[str] = "https://kemono.cr/api/v1"
 
@@ -26,21 +27,24 @@ class Kemono:
     async def get_post(self, service: str, user_id: str, post_id: str) -> dict:
         """Fetch a post."""
         api = f"{self.API_BASE}/{service}/user/{user_id}/post/{post_id}"
-        async with Request() as request, request.get(api, headers=self.HEADERS) as response:
+        async with (
+            Request() as request,
+            request.get(api, headers=self.HEADERS) as response,
+        ):
             if response.status == 403:
                 content = await response.text()
                 raise NazurinError(f"403 Forbidden: {content[:100]}")
-            
+
             response.raise_for_status()
 
             data = await response.json(content_type=None)
-        
-            post = data.get("post", data) 
-            
+
+            post = data.get("post", data)
+
             username = await self.get_username(service, user_id)
             post["username"] = username
             return post
-            
+
     @network_retry
     async def get_post_revision(
         self,
@@ -51,7 +55,10 @@ class Kemono:
     ) -> dict:
         """Fetch a post revision."""
         api = f"{self.API_BASE}/{service}/user/{user_id}/post/{post_id}/revisions"
-        async with Request() as request, request.get(api, headers=self.HEADERS) as response:
+        async with (
+            Request() as request,
+            request.get(api, headers=self.HEADERS) as response,
+        ):
             response.raise_for_status()
             revisions = await response.json(content_type=None)
             post = None
@@ -68,13 +75,16 @@ class Kemono:
     @network_retry
     async def get_username(self, service: str, user_id: str) -> str:
         url = f"{self.API_BASE}/{service}/user/{user_id}/profile"
-        async with Request() as request, request.get(url, headers=self.HEADERS) as response:
+        async with (
+            Request() as request,
+            request.get(url, headers=self.HEADERS) as response,
+        ):
             response.raise_for_status()
             profile = await response.json(content_type=None)
             if isinstance(profile, list) and len(profile) > 0:
                 return profile[0].get("name", "")
             return profile.get("name", "")
-            
+
     async def fetch(
         self,
         service: str,
@@ -119,9 +129,9 @@ class Kemono:
                 f"{image_index} - {file['name']}",
                 path,
             )
-            
+
             thumbnail = f"https://img.kemono.cr/thumbnail/data{path}"
-            
+
             images.append(
                 Image(
                     filename,
@@ -146,7 +156,9 @@ class Kemono:
             if not time_str or not isinstance(time_str, str):
                 return datetime(1970, 1, 1, tzinfo=timezone.utc)
             try:
-                return datetime.fromisoformat(time_str.replace('Z', '+00:00')).replace(tzinfo=timezone.utc)
+                return datetime.fromisoformat(time_str.replace("Z", "+00:00")).replace(
+                    tzinfo=timezone.utc
+                )
             except (ValueError, TypeError):
                 return datetime(1970, 1, 1, tzinfo=timezone.utc)
 

--- a/nazurin/sites/kemono/api.py
+++ b/nazurin/sites/kemono/api.py
@@ -11,24 +11,38 @@ from nazurin.utils.exceptions import NazurinError
 
 from .config import DESTINATION, FILENAME
 
+from urllib.parse import quote
+
 
 class Kemono:
-    API_BASE: ClassVar[str] = "https://kemono.su/api/v1"
+    API_BASE: ClassVar[str] = "https://kemono.cr/api/v1"
+
+    HEADERS: ClassVar[dict] = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36",
+        "Referer": "https://kemono.cr/",
+        "Accept": "text/css",
+        "Accept-Language": "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7,zh-TW;q=0.6",
+    }
 
     @network_retry
     async def get_post(self, service: str, user_id: str, post_id: str) -> dict:
-        """Fetch an post."""
+        """Fetch a post."""
         api = f"{self.API_BASE}/{service}/user/{user_id}/post/{post_id}"
-        async with Request() as request, request.get(api) as response:
+        async with Request() as request, request.get(api, headers=self.HEADERS) as response:
+            if response.status == 403:
+                content = await response.text()
+                raise NazurinError(f"403 Forbidden.")
+            
             response.raise_for_status()
-            post = await response.json()
-            if not post:
-                raise NazurinError("Post not found")
-            post = post["post"]
+
+            data = await response.json(content_type=None)
+        
+            post = data.get("post", data) 
+            
             username = await self.get_username(service, user_id)
             post["username"] = username
             return post
-
+            
     @network_retry
     async def get_post_revision(
         self,
@@ -39,9 +53,9 @@ class Kemono:
     ) -> dict:
         """Fetch a post revision."""
         api = f"{self.API_BASE}/{service}/user/{user_id}/post/{post_id}/revisions"
-        async with Request() as request, request.get(api) as response:
+        async with Request() as request, request.get(api, headers=self.HEADERS) as response:
             response.raise_for_status()
-            revisions = await response.json()
+            revisions = await response.json(content_type=None)
             post = None
             for revision in revisions:
                 if str(revision["revision_id"]) == revision_id:
@@ -56,11 +70,13 @@ class Kemono:
     @network_retry
     async def get_username(self, service: str, user_id: str) -> str:
         url = f"{self.API_BASE}/{service}/user/{user_id}/profile"
-        async with Request() as request, request.get(url) as response:
+        async with Request() as request, request.get(url, headers=self.HEADERS) as response:
             response.raise_for_status()
-            profile = await response.json()
+            profile = await response.json(content_type=None)
+            if isinstance(profile, list) and len(profile) > 0:
+                return profile[0].get("name", "")
             return profile.get("name", "")
-
+            
     async def fetch(
         self,
         service: str,
@@ -77,14 +93,19 @@ class Kemono:
         images = []
         download_files = []
         files = [post["file"]] if post.get("file") else []
-        files += post["attachments"]
+        #files += post["attachments"]
+        files += post.get("attachments", [])
+
         if not files:
             raise NazurinError("No files found")
 
         image_index = 0
         for file in files:
             path: str = file["path"]
-            url = "https://c1.kemono.su/data" + path
+            file_name_param = file.get("name", "")
+
+            encoded_filename = quote(file_name_param)
+            url = f"https://n2.kemono.cr/data{path}?f={encoded_filename}"
 
             # Handle non-image files
             if not self.is_image(path):
@@ -101,7 +122,9 @@ class Kemono:
                 f"{image_index} - {file['name']}",
                 path,
             )
-            thumbnail = "https://img.kemono.su/thumbnail/data" + path
+            
+            thumbnail = f"https://img.kemono.cr/thumbnail/data{path}"
+            
             images.append(
                 Image(
                     filename,
@@ -121,12 +144,18 @@ class Kemono:
         Format destination and filename.
         """
 
-        def parse_time(time: str) -> str:
-            return datetime.fromisoformat(time).replace(tzinfo=timezone.utc)
+        def parse_time(time_str):
+            # Define default time (1970-01-01)
+            if not time_str or not isinstance(time_str, str):
+                return datetime(1970, 1, 1, tzinfo=timezone.utc)
+            try:
+                return datetime.fromisoformat(time_str.replace('Z', '+00:00')).replace(tzinfo=timezone.utc)
+            except (ValueError, TypeError):
+                return datetime(1970, 1, 1, tzinfo=timezone.utc)
 
-        added = parse_time(post["added"])
-        edited = parse_time(post["edited"] or post["added"])
-        published = parse_time(post["published"])
+        added = parse_time(post.get("added"))
+        edited = parse_time(post.get("edited") or post.get("added"))
+        published = parse_time(post.get("published") or post.get("added"))
         pretty_name, _ = os.path.splitext(pretty_name)
         filename, extension = os.path.splitext(path)
         context = {

--- a/nazurin/sites/kemono/api.py
+++ b/nazurin/sites/kemono/api.py
@@ -35,7 +35,7 @@ class Kemono:
             Request() as request,
             request.get(api, headers=self.HEADERS) as response,
         ):
-            if response.status == 403: # noqa: PLR2004
+            if response.status == 403:  # noqa: PLR2004
                 content = await response.text()
                 raise NazurinError(f"403 Forbidden: {content[:100]}")
 

--- a/nazurin/sites/kemono/api.py
+++ b/nazurin/sites/kemono/api.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime, timezone
 from mimetypes import guess_type
 from typing import ClassVar
+from urllib.parse import quote
 
 from nazurin.models import Caption, Illust, Image
 from nazurin.models.file import File
@@ -10,9 +11,6 @@ from nazurin.utils.decorators import network_retry
 from nazurin.utils.exceptions import NazurinError
 
 from .config import DESTINATION, FILENAME
-
-from urllib.parse import quote
-
 
 class Kemono:
     API_BASE: ClassVar[str] = "https://kemono.cr/api/v1"
@@ -31,7 +29,7 @@ class Kemono:
         async with Request() as request, request.get(api, headers=self.HEADERS) as response:
             if response.status == 403:
                 content = await response.text()
-                raise NazurinError(f"403 Forbidden.")
+                raise NazurinError(f"403 Forbidden: {content[:100]}")
             
             response.raise_for_status()
 
@@ -93,7 +91,6 @@ class Kemono:
         images = []
         download_files = []
         files = [post["file"]] if post.get("file") else []
-        #files += post["attachments"]
         files += post.get("attachments", [])
 
         if not files:

--- a/nazurin/sites/kemono/interface.py
+++ b/nazurin/sites/kemono/interface.py
@@ -15,7 +15,7 @@ patterns = [
     # https://kemono.party/gumroad/user/12345/post/aBc1d2
     # https://kemono.su/subscribestar/user/abcdef/post/12345
     # https://kemono.su/fanbox/user/12345/post/12345/revision/12345
-    r"kemono\.(?:party|su)/(\w+)/user/([\w-]+)/post/([\w-]+)(?:/revision/(\d+))?",
+    r"kemono\.(?:party|su|cr)/(\w+)/user/([\w-]+)/post/([\w-]+)(?:/revision/(\d+))?",
 ]
 
 

--- a/nazurin/sites/kemono/interface.py
+++ b/nazurin/sites/kemono/interface.py
@@ -13,8 +13,8 @@ patterns = [
     # https://kemono.party/boosty/user/abcdef/post/a1b2c3-d4e5f6-7890
     # https://kemono.party/dlsite/user/RG12345/post/RE12345
     # https://kemono.party/gumroad/user/12345/post/aBc1d2
-    # https://kemono.su/subscribestar/user/abcdef/post/12345
-    # https://kemono.su/fanbox/user/12345/post/12345/revision/12345
+    # https://kemono.cr/subscribestar/user/abcdef/post/12345
+    # https://kemono.cr/fanbox/user/12345/post/12345/revision/12345
     r"kemono\.(?:party|su|cr)/(\w+)/user/([\w-]+)/post/([\w-]+)(?:/revision/(\d+))?",
 ]
 


### PR DESCRIPTION

1. Following the Kemono developer's recommendation ("If you want to scrape, use 'Accept: text/css' header in your requests for now. For whatever reason DDG does not like SPA and JSON, so we have to be funny."), so added the headers to use `Accept: text/css`.
2. Forced JSON decoding using `content_type=None` since the server now responds with `text/css` headers when using the bypass.
3. Migrated endpoints from `.su` to `.cr` (and `n2.kemono.cr` for resources). Also implemented URL encoding for filenames using `urllib.parse.quote`.
4. Implemented a safer `parse_time` helper to handle missing or malformed ISO timestamps and utilized `.get()` for safer dictionary access throughout the module.

Tested locally on multiple Fanbox/Patreon posts.