### PR TITLE
feat: add Telegraph site support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -191,6 +191,10 @@ DATABASE = Local
 # File name
 # TWITTER_FILE_NAME = {id_str}_{index} - {user[name]}({user[id_str]})
 
+# ----- Telegraph -----
+# File directory
+# TELEGRAPH_FILE_PATH = Telegraph/{archive_name}
+
 # ----- Wallhaven -----
 # API key, optional
 # WALLHAVEN_API_KEY =

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 |    DeviantArt     | <https://www.deviantart.com/>  |          |     ✔      |
 |      Lofter       |   <https://www.lofter.com/>    |          |     ✔      |
 |   Kemono.party    |    <https://kemono.party/>     |          |     ✔      |
+|     Telegraph     | <https://telegra.ph/>, <https://graph.org/> |          |     ✔      |
 |      Bluesky      |      <https://bsky.app/>       |          |     ✔      |
 
 ### Supported Databases

--- a/docs/includes/site.md
+++ b/docs/includes/site.md
@@ -1,19 +1,20 @@
-|       Name        |              URL               | Commands | Image Collection |
-| :---------------: | :----------------------------: | :------: | :--------------: |
-|       Pixiv       |    <https://www.pixiv.net/>    |    ✔     |        ✔         |
-|     Danbooru      | <https://danbooru.donmai.us/>  |    ✔     |        ✔         |
-|     Safebooru     | <https://safebooru.donmai.us/> |          |        ✔         |
-|      yandere      |      <https://yande.re/>       |    ✔     |        ✔         |
-|     Konachan      |    <https://konachan.com/>     |    ✔     |        ✔         |
-|     Lolibooru     |    <https://lolibooru.moe/>    |          |        ✔         |
-|     Zerochan      |  <https://www.zerochan.net/>   |    ✔     |        ✔         |
-|     Gelbooru      |    <https://gelbooru.com/>     |          |        ✔         |
-|      Twitter      |     <https://twitter.com/>     |    ✔     |        ✔         |
-|    ArtStation     | <https://www.artstation.com/>  |          |        ✔         |
-|     Wallhaven     |    <https://wallhaven.cc/>     |          |        ✔         |
-| Bilibili Dynamics |   <https://t.bilibili.com/>    |          |        ✔         |
-|       Weibo       |      <https://weibo.com/>      |          |        ✔         |
-|    DeviantArt     | <https://www.deviantart.com/>  |          |        ✔         |
-|      Lofter       |   <https://www.lofter.com/>    |          |        ✔         |
-|   Kemono.party    |    <https://kemono.party/>     |          |        ✔         |
-|      Bluesky      |      <https://bsky.app/>       |          |        ✔         |
+|       Name        |                     URL                     | Commands | Image Collection |
+| :---------------: | :-----------------------------------------: | :------: | :--------------: |
+|       Pixiv       |          <https://www.pixiv.net/>           |    ✔     |        ✔         |
+|     Danbooru      |        <https://danbooru.donmai.us/>        |    ✔     |        ✔         |
+|     Safebooru     |       <https://safebooru.donmai.us/>        |          |        ✔         |
+|      yandere      |             <https://yande.re/>             |    ✔     |        ✔         |
+|     Konachan      |           <https://konachan.com/>           |    ✔     |        ✔         |
+|     Lolibooru     |          <https://lolibooru.moe/>           |          |        ✔         |
+|     Zerochan      |         <https://www.zerochan.net/>         |    ✔     |        ✔         |
+|     Gelbooru      |           <https://gelbooru.com/>           |          |        ✔         |
+|      Twitter      |           <https://twitter.com/>            |    ✔     |        ✔         |
+|    ArtStation     |        <https://www.artstation.com/>        |          |        ✔         |
+|     Wallhaven     |           <https://wallhaven.cc/>           |          |        ✔         |
+| Bilibili Dynamics |          <https://t.bilibili.com/>          |          |        ✔         |
+|       Weibo       |            <https://weibo.com/>             |          |        ✔         |
+|    DeviantArt     |        <https://www.deviantart.com/>        |          |        ✔         |
+|      Lofter       |          <https://www.lofter.com/>          |          |        ✔         |
+|   Kemono.party    |           <https://kemono.party/>           |          |        ✔         |
+|     Telegraph     | <https://telegra.ph/>, <https://graph.org/> |          |        ✔         |
+|      Bluesky      |             <https://bsky.app/>             |          |        ✔         |

--- a/docs/includes/site.zh.md
+++ b/docs/includes/site.zh.md
@@ -1,19 +1,20 @@
-|     名称     |              URL               | 命令 | 图片收藏 |
-| :----------: | :----------------------------: | :--: | :------: |
-|    Pixiv     |    <https://www.pixiv.net/>    |  ✔   |    ✔     |
-|   Danbooru   | <https://danbooru.donmai.us/>  |  ✔   |    ✔     |
-|  Safebooru   | <https://safebooru.donmai.us/> |      |    ✔     |
-|   yandere    |      <https://yande.re/>       |  ✔   |    ✔     |
-|   Konachan   |    <https://konachan.com/>     |  ✔   |    ✔     |
-|  Lolibooru   |    <https://lolibooru.moe/>    |      |    ✔     |
-|   Zerochan   |  <https://www.zerochan.net/>   |  ✔   |    ✔     |
-|   Gelbooru   |    <https://gelbooru.com/>     |      |    ✔     |
-|   Twitter    |     <https://twitter.com/>     |  ✔   |    ✔     |
-|  ArtStation  | <https://www.artstation.com/>  |      |    ✔     |
-|  Wallhaven   |    <https://wallhaven.cc/>     |      |    ✔     |
-| 哔哩哔哩动态 |   <https://t.bilibili.com/>    |      |    ✔     |
-|     微博     |      <https://weibo.com/>      |      |    ✔     |
-|  DeviantArt  | <https://www.deviantart.com/>  |      |    ✔     |
-|    Lofter    |   <https://www.lofter.com/>    |      |    ✔     |
-| Kemono.party |    <https://kemono.party/>     |      |    ✔     |
-|   Bluesky    |      <https://bsky.app/>       |      |    ✔     |
+|     名称     |                     URL                     | 命令 | 图片收藏 |
+| :----------: | :-----------------------------------------: | :--: | :------: |
+|    Pixiv     |          <https://www.pixiv.net/>           |  ✔   |    ✔     |
+|   Danbooru   |        <https://danbooru.donmai.us/>        |  ✔   |    ✔     |
+|  Safebooru   |       <https://safebooru.donmai.us/>        |      |    ✔     |
+|   yandere    |             <https://yande.re/>             |  ✔   |    ✔     |
+|   Konachan   |           <https://konachan.com/>           |  ✔   |    ✔     |
+|  Lolibooru   |          <https://lolibooru.moe/>           |      |    ✔     |
+|   Zerochan   |         <https://www.zerochan.net/>         |  ✔   |    ✔     |
+|   Gelbooru   |           <https://gelbooru.com/>           |      |    ✔     |
+|   Twitter    |           <https://twitter.com/>            |  ✔   |    ✔     |
+|  ArtStation  |        <https://www.artstation.com/>        |      |    ✔     |
+|  Wallhaven   |           <https://wallhaven.cc/>           |      |    ✔     |
+| 哔哩哔哩动态 |          <https://t.bilibili.com/>          |      |    ✔     |
+|     微博     |            <https://weibo.com/>             |      |    ✔     |
+|  DeviantArt  |        <https://www.deviantart.com/>        |      |    ✔     |
+|    Lofter    |          <https://www.lofter.com/>          |      |    ✔     |
+| Kemono.party |           <https://kemono.party/>           |      |    ✔     |
+|  Telegraph   | <https://telegra.ph/>, <https://graph.org/> |      |    ✔     |
+|   Bluesky    |             <https://bsky.app/>             |      |    ✔     |

--- a/docs/site/telegraph.md
+++ b/docs/site/telegraph.md
@@ -1,0 +1,41 @@
+# Telegraph
+
+<https://telegra.ph/>, <https://graph.org/>
+
+Nazurin archives Telegraph pages through the official `getPage/<path>` API with `return_content=true`. Browser automation is not required.
+
+Each page is stored as a directory containing the original API response, an offline HTML article, and downloaded images:
+
+```text
+Telegraph/
+└── <sanitized-title> (<12-char-path-hash>)/
+    ├── article.html
+    ├── page.json
+    └── assets/
+        ├── 001.jpg
+        ├── 002.png
+        └── ...
+```
+
+- `article.html` preserves the supported text structure and references downloaded images using relative paths.
+- `page.json` contains the complete response returned by the Telegraph API.
+- Images are numbered in document order. If an image cannot be downloaded, the HTML keeps its original URL as a clickable link, so numbering may contain gaps. Videos and iframe content are not downloaded; their links are preserved.
+
+## Customizing Storage Path
+
+For more information, refer to [Customizing Storage Path & File Name](./index.md/#customizing-storage-path--file-name).
+
+### TELEGRAPH_FILE_PATH
+
+:material-lightbulb-on: Optional, defaults to `Telegraph/{archive_name}`
+
+### Available Variables
+
+```json
+{
+  "archive_name": "Sanitized page title followed by a stable 12-character path hash",
+  "title": "Page title returned by Telegraph",
+  "path": "Normalized Telegraph page path",
+  "path_hash": "First 12 characters of the SHA-256 hash of the page path"
+}
+```

--- a/docs/site/telegraph.md
+++ b/docs/site/telegraph.md
@@ -35,6 +35,7 @@ For more information, refer to [Customizing Storage Path & File Name](./index.md
 {
   "archive_name": "Sanitized page title followed by a stable 12-character path hash",
   "title": "Page title returned by Telegraph",
+  "author_name": "Author name",
   "path": "Normalized Telegraph page path",
   "path_hash": "First 12 characters of the SHA-256 hash of the page path"
 }

--- a/docs/site/telegraph.zh.md
+++ b/docs/site/telegraph.zh.md
@@ -1,0 +1,42 @@
+# Telegraph
+
+<https://telegra.ph/>，<https://graph.org/>
+
+Nazurin 通过 Telegraph 官方 `getPage/<path>` API 并设置 `return_content=true` 来归档页面，不需要浏览器自动化。
+
+每个页面以独立目录保存，其中包含原始 API 响应、可离线阅读的 HTML 文章和下载的图片：
+
+```text
+Telegraph/
+└── <清理后的标题> (<12 位 path hash>)/
+    ├── article.html
+    ├── page.json
+    └── assets/
+        ├── 001.jpg
+        ├── 002.png
+        └── ...
+```
+
+- `article.html` 保留支持的正文结构，并使用相对路径引用已下载图片。
+- `page.json` 保存 Telegraph API 返回的完整响应。
+- 图片按照正文中的出现顺序编号。图片下载失败时，HTML 会保留其原始 URL 作为可点击链接，因此编号可能出现空缺。视频和 iframe 内容不会下载，将保留链接。
+
+## 自定义存储路径
+
+更多信息请查阅 [自定义存储路径和文件名](./index.zh.md/#customizing-storage-path--file-name)。
+
+### TELEGRAPH_FILE_PATH
+
+:material-lightbulb-on: 可选，默认为 `Telegraph/{archive_name}`
+
+
+### 可用变量
+
+```json
+{
+  "archive_name": "清理后的页面标题和稳定的 12 位 path hash",
+  "title": "Telegraph 返回的页面标题",
+  "path": "规范化后的 Telegraph page path",
+  "path_hash": "page path 的 SHA-256 哈希前 12 位"
+}
+```

--- a/docs/site/telegraph.zh.md
+++ b/docs/site/telegraph.zh.md
@@ -36,6 +36,7 @@ Telegraph/
 {
   "archive_name": "清理后的页面标题和稳定的 12 位 path hash",
   "title": "Telegraph 返回的页面标题",
+  "author_name": "作者名称",
   "path": "规范化后的 Telegraph page path",
   "path_hash": "page path 的 SHA-256 哈希前 12 位"
 }

--- a/nazurin/models/file.py
+++ b/nazurin/models/file.py
@@ -1,6 +1,6 @@
 import os
 import pathlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import aiofiles
 import aiofiles.os
@@ -21,6 +21,11 @@ class File:
     name: str
     url: str = None
     _destination: str = ""
+    local_path: str | os.PathLike | None = field(
+        default=None,
+        kw_only=True,
+        repr=False,
+    )
 
     def __post_init__(self):
         self.name = sanitize_filename(self.name)
@@ -30,6 +35,8 @@ class File:
         """
         Path to the file in temporary directory.
         """
+        if self.local_path is not None:
+            return os.fspath(self.local_path)
         return os.path.join(TEMP_DIR, self.name)
 
     @property
@@ -66,7 +73,7 @@ class File:
         if await self.exists():
             logger.info("File {} already exists", self.path)
             return await self.size()
-        await ensure_existence_async(TEMP_DIR)
+        await ensure_existence_async(os.path.dirname(self.path) or TEMP_DIR)
         logger.info("Downloading {} to {}...", self.url, self.path)
         await session.download(self.url, self.path)
         size = await self.size()

--- a/nazurin/models/file.py
+++ b/nazurin/models/file.py
@@ -21,8 +21,8 @@ class File:
     name: str
     url: str = None
     _destination: str = ""
-    local_path: str | os.PathLike | None = field(
-        default=None,
+    _local_dir: str = field(
+        default=TEMP_DIR,
         kw_only=True,
         repr=False,
     )
@@ -35,9 +35,16 @@ class File:
         """
         Path to the file in temporary directory.
         """
-        if self.local_path is not None:
-            return os.fspath(self.local_path)
-        return os.path.join(TEMP_DIR, self.name)
+        return os.path.join(self._local_dir, self.name)
+
+    @property
+    def local_dir(self) -> str:
+        """Local directory containing the file, without the file name."""
+        return self._local_dir
+
+    @local_dir.setter
+    def local_dir(self, value: str | os.PathLike):
+        self._local_dir = os.fspath(value)
 
     @property
     def destination(self) -> pathlib.Path:

--- a/nazurin/sites/telegraph/__init__.py
+++ b/nazurin/sites/telegraph/__init__.py
@@ -1,0 +1,7 @@
+"""Telegraph site plugin."""
+
+from .api import Telegraph
+from .config import PRIORITY
+from .interface import handle, patterns
+
+__all__ = ["PRIORITY", "Telegraph", "handle", "patterns"]

--- a/nazurin/sites/telegraph/api.py
+++ b/nazurin/sites/telegraph/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from http import HTTPStatus
 from json import JSONDecodeError
 from pathlib import PurePath
+from typing import TypeAlias, Union
 
 from aiohttp import ContentTypeError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -19,10 +20,13 @@ class TelegraphModel(BaseModel):
     model_config = ConfigDict(extra="allow", strict=True)
 
 
+TelegraphNode: TypeAlias = Union[str, "TelegraphNodeElement"]
+
+
 class TelegraphNodeElement(TelegraphModel):
     tag: str
     attrs: dict[str, str] | None = None
-    children: list[str | TelegraphNodeElement] | None = None
+    children: list[TelegraphNode] | None = None
 
 
 class TelegraphPage(TelegraphModel):
@@ -33,7 +37,7 @@ class TelegraphPage(TelegraphModel):
     author_name: str | None = None
     author_url: str | None = None
     image_url: str | None = None
-    content: list[str | TelegraphNodeElement]
+    content: list[TelegraphNode] = Field(default_factory=list)
     views: int
     can_edit: bool | None = None
 
@@ -48,8 +52,8 @@ class Telegraph:
     API_BASE = "https://api.telegra.ph"
 
     @network_retry
-    async def get_page(self, page_path: str) -> tuple[dict, dict]:
-        """Fetch a Telegraph page and return the raw envelope and page data."""
+    async def get_page(self, page_path: str) -> tuple[dict, TelegraphPage]:
+        """Fetch a Telegraph page and return its raw envelope and validated page."""
         api_url = f"{self.API_BASE}/getPage/{page_path}"
         async with (
             Request() as request,
@@ -76,8 +80,7 @@ class Telegraph:
 
         if api_response.result is None:
             raise NazurinError("Invalid Telegraph API response")
-        page = api_response.result.model_dump(exclude_unset=True)
-        return envelope, page
+        return envelope, api_response.result
 
     async def fetch(self, page_path: str, source_url: str) -> TelegraphIllust:
         envelope, page = await self.get_page(page_path)
@@ -85,11 +88,11 @@ class Telegraph:
         return TelegraphIllust(envelope, page, source_url, destination)
 
     @staticmethod
-    def get_storage_destination(page: dict) -> str:
+    def get_storage_destination(page: TelegraphPage) -> str:
         values = {
-            **page,
+            **page.model_dump(exclude_unset=True),
             "archive_name": build_archive_name(page),
-            "path_hash": build_path_hash(page["path"]),
+            "path_hash": build_path_hash(page.path),
         }
         try:
             destination = DESTINATION.format_map(values)

--- a/nazurin/sites/telegraph/api.py
+++ b/nazurin/sites/telegraph/api.py
@@ -1,4 +1,3 @@
-import hashlib
 from http import HTTPStatus
 from json import JSONDecodeError
 from pathlib import PurePath
@@ -11,7 +10,7 @@ from nazurin.utils.decorators import network_retry
 from nazurin.utils.exceptions import NazurinError
 
 from .config import DESTINATION
-from .models import PATH_HASH_LENGTH, TelegraphIllust, build_archive_name
+from .models import TelegraphIllust, build_archive_name, build_path_hash
 
 ASCII_CONTROL_END = 32
 ASCII_DELETE = 127
@@ -85,9 +84,7 @@ class Telegraph:
         values = {
             **page,
             "archive_name": build_archive_name(page),
-            "path_hash": hashlib.sha256(page["path"].encode()).hexdigest()[
-                :PATH_HASH_LENGTH
-            ],
+            "path_hash": build_path_hash(page["path"]),
         }
         try:
             destination = DESTINATION.format_map(values)

--- a/nazurin/sites/telegraph/api.py
+++ b/nazurin/sites/telegraph/api.py
@@ -1,0 +1,100 @@
+import hashlib
+from http import HTTPStatus
+from json import JSONDecodeError
+from pathlib import PurePath
+from urllib.parse import quote, unquote
+
+from aiohttp import ContentTypeError
+
+from nazurin.utils import Request
+from nazurin.utils.decorators import network_retry
+from nazurin.utils.exceptions import NazurinError
+
+from .config import DESTINATION
+from .models import PATH_HASH_LENGTH, TelegraphIllust, build_archive_name
+
+ASCII_CONTROL_END = 32
+ASCII_DELETE = 127
+
+
+def validate_page_path(value: str) -> str:
+    """Validate and normalize a single-segment Telegraph page path."""
+    page_path = unquote(value).strip("/")
+    if (
+        not page_path
+        or page_path in {".", ".."}
+        or "/" in page_path
+        or "\\" in page_path
+        or any(
+            ord(char) < ASCII_CONTROL_END or ord(char) == ASCII_DELETE
+            for char in page_path
+        )
+    ):
+        raise NazurinError("Invalid Telegraph page path")
+    return page_path
+
+
+class Telegraph:
+    API_BASE = "https://api.telegra.ph"
+
+    @network_retry
+    async def get_page(self, page_path: str) -> tuple[dict, dict]:
+        """Fetch a Telegraph page and return the raw envelope and page data."""
+        api_url = f"{self.API_BASE}/getPage/{quote(page_path, safe='')}"
+        async with (
+            Request() as request,
+            request.get(
+                api_url,
+                params={"return_content": "true"},
+            ) as response,
+        ):
+            if response.status == HTTPStatus.NOT_FOUND:
+                raise NazurinError("Telegraph page not found")
+            response.raise_for_status()
+            try:
+                envelope = await response.json()
+            except (ContentTypeError, JSONDecodeError, ValueError) as error:
+                raise NazurinError("Invalid Telegraph API response") from error
+
+        if not isinstance(envelope, dict) or not isinstance(envelope.get("ok"), bool):
+            raise NazurinError("Invalid Telegraph API response")
+        if not envelope["ok"]:
+            message = envelope.get("error") or "Unknown Telegraph API error"
+            raise NazurinError(f"Telegraph API error: {message}")
+
+        page = envelope.get("result")
+        if not isinstance(page, dict):
+            raise NazurinError("Invalid Telegraph API response")
+        if not isinstance(page.get("path"), str):
+            raise NazurinError("Invalid Telegraph API response")
+        if not isinstance(page.get("title"), str) or not page["title"]:
+            raise NazurinError("Invalid Telegraph API response")
+        if not isinstance(page.get("content"), list):
+            raise NazurinError("Invalid Telegraph API response")
+
+        page = {**page, "path": validate_page_path(page["path"])}
+        return envelope, page
+
+    async def fetch(self, page_path: str, source_url: str) -> TelegraphIllust:
+        envelope, page = await self.get_page(page_path)
+        destination = self.get_storage_destination(page)
+        return TelegraphIllust(envelope, page, source_url, destination)
+
+    @staticmethod
+    def get_storage_destination(page: dict) -> str:
+        values = {
+            **page,
+            "archive_name": build_archive_name(page),
+            "path_hash": hashlib.sha256(page["path"].encode()).hexdigest()[
+                :PATH_HASH_LENGTH
+            ],
+        }
+        try:
+            destination = DESTINATION.format_map(values)
+        except (KeyError, ValueError) as error:
+            raise NazurinError("Invalid Telegraph file path template") from error
+
+        parsed = PurePath(destination)
+        if parsed.is_absolute() or not parsed.parts or ".." in parsed.parts:
+            raise NazurinError("Invalid Telegraph file destination")
+        return destination

--- a/nazurin/sites/telegraph/api.py
+++ b/nazurin/sites/telegraph/api.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from http import HTTPStatus
 from json import JSONDecodeError
 from pathlib import PurePath
-from urllib.parse import quote, unquote
 
 from aiohttp import ContentTypeError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from nazurin.utils import Request
 from nazurin.utils.decorators import network_retry
@@ -12,25 +14,34 @@ from nazurin.utils.exceptions import NazurinError
 from .config import DESTINATION
 from .models import TelegraphIllust, build_archive_name, build_path_hash
 
-ASCII_CONTROL_END = 32
-ASCII_DELETE = 127
+
+class TelegraphModel(BaseModel):
+    model_config = ConfigDict(extra="allow", strict=True)
 
 
-def validate_page_path(value: str) -> str:
-    """Validate and normalize a single-segment Telegraph page path."""
-    page_path = unquote(value).strip("/")
-    if (
-        not page_path
-        or page_path in {".", ".."}
-        or "/" in page_path
-        or "\\" in page_path
-        or any(
-            ord(char) < ASCII_CONTROL_END or ord(char) == ASCII_DELETE
-            for char in page_path
-        )
-    ):
-        raise NazurinError("Invalid Telegraph page path")
-    return page_path
+class TelegraphNodeElement(TelegraphModel):
+    tag: str
+    attrs: dict[str, str] | None = None
+    children: list[str | TelegraphNodeElement] | None = None
+
+
+class TelegraphPage(TelegraphModel):
+    path: str
+    url: str
+    title: str = Field(min_length=1)
+    description: str
+    author_name: str | None = None
+    author_url: str | None = None
+    image_url: str | None = None
+    content: list[str | TelegraphNodeElement]
+    views: int
+    can_edit: bool | None = None
+
+
+class TelegraphResponse(TelegraphModel):
+    ok: bool
+    result: TelegraphPage | None = None
+    error: str | None = None
 
 
 class Telegraph:
@@ -39,7 +50,7 @@ class Telegraph:
     @network_retry
     async def get_page(self, page_path: str) -> tuple[dict, dict]:
         """Fetch a Telegraph page and return the raw envelope and page data."""
-        api_url = f"{self.API_BASE}/getPage/{quote(page_path, safe='')}"
+        api_url = f"{self.API_BASE}/getPage/{page_path}"
         async with (
             Request() as request,
             request.get(
@@ -55,23 +66,17 @@ class Telegraph:
             except (ContentTypeError, JSONDecodeError, ValueError) as error:
                 raise NazurinError("Invalid Telegraph API response") from error
 
-        if not isinstance(envelope, dict) or not isinstance(envelope.get("ok"), bool):
-            raise NazurinError("Invalid Telegraph API response")
-        if not envelope["ok"]:
-            message = envelope.get("error") or "Unknown Telegraph API error"
+        try:
+            api_response = TelegraphResponse.model_validate(envelope)
+        except ValidationError as error:
+            raise NazurinError("Invalid Telegraph API response") from error
+        if not api_response.ok:
+            message = api_response.error or "Unknown Telegraph API error"
             raise NazurinError(f"Telegraph API error: {message}")
 
-        page = envelope.get("result")
-        if not isinstance(page, dict):
+        if api_response.result is None:
             raise NazurinError("Invalid Telegraph API response")
-        if not isinstance(page.get("path"), str):
-            raise NazurinError("Invalid Telegraph API response")
-        if not isinstance(page.get("title"), str) or not page["title"]:
-            raise NazurinError("Invalid Telegraph API response")
-        if not isinstance(page.get("content"), list):
-            raise NazurinError("Invalid Telegraph API response")
-
-        page = {**page, "path": validate_page_path(page["path"])}
+        page = api_response.result.model_dump(exclude_unset=True)
         return envelope, page
 
     async def fetch(self, page_path: str, source_url: str) -> TelegraphIllust:

--- a/nazurin/sites/telegraph/config.py
+++ b/nazurin/sites/telegraph/config.py
@@ -1,0 +1,7 @@
+from nazurin.config import env
+
+PRIORITY = 10
+COLLECTION = "telegraph"
+
+with env.prefixed("TELEGRAPH_"), env.prefixed("FILE_"):
+    DESTINATION: str = env.str("PATH", default="Telegraph/{archive_name}")

--- a/nazurin/sites/telegraph/interface.py
+++ b/nazurin/sites/telegraph/interface.py
@@ -1,0 +1,45 @@
+import re
+from urllib.parse import quote, urlsplit
+
+from nazurin.models import Document
+from nazurin.sites import HandlerResult
+from nazurin.utils.exceptions import NazurinError
+
+from .api import Telegraph, validate_page_path
+from .config import COLLECTION
+
+SUPPORTED_HOSTS = {"graph.org", "telegra.ph"}
+
+patterns = [
+    r"(?P<url>(?i:https?://(?:telegra\.ph|graph\.org)/[^\s,]+))",
+]
+
+
+def normalize_page_url(url: str) -> tuple[str, str]:
+    """Return a canonical page path and source URL."""
+    try:
+        parsed = urlsplit(url)
+        port = parsed.port
+    except ValueError as error:
+        raise NazurinError("Invalid Telegraph URL") from error
+
+    host = (parsed.hostname or "").lower()
+    if (
+        parsed.scheme.lower() not in {"http", "https"}
+        or host not in SUPPORTED_HOSTS
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+    ):
+        raise NazurinError("Invalid Telegraph URL")
+
+    page_path = validate_page_path(parsed.path)
+    source_url = f"https://{host}/{quote(page_path, safe='')}"
+    return page_path, source_url
+
+
+async def handle(match: re.Match) -> HandlerResult:
+    page_path, source_url = normalize_page_url(match.group("url"))
+    illust = await Telegraph().fetch(page_path, source_url)
+    document = Document(id=illust.id, collection=COLLECTION, data=illust.metadata)
+    return illust, document

--- a/nazurin/sites/telegraph/interface.py
+++ b/nazurin/sites/telegraph/interface.py
@@ -1,39 +1,24 @@
 import re
-from urllib.parse import quote, urlsplit
+from urllib.parse import quote, unquote, urlsplit
 
 from nazurin.models import Document
 from nazurin.sites import HandlerResult
-from nazurin.utils.exceptions import NazurinError
 
-from .api import Telegraph, validate_page_path
+from .api import Telegraph
 from .config import COLLECTION
 
-SUPPORTED_HOSTS = {"graph.org", "telegra.ph"}
-
 patterns = [
-    r"(?P<url>(?i:https?://(?:telegra\.ph|graph\.org)/[^\s,]+))",
+    r"(?:^|,)(?P<url>(?i:https?://(?:telegra\.ph|graph\.org)/[\w%-]+))"
+    r"(?=,|$)",
 ]
 
 
 def normalize_page_url(url: str) -> tuple[str, str]:
     """Return a canonical page path and source URL."""
-    try:
-        parsed = urlsplit(url)
-        port = parsed.port
-    except ValueError as error:
-        raise NazurinError("Invalid Telegraph URL") from error
-
-    host = (parsed.hostname or "").lower()
-    if (
-        parsed.scheme.lower() not in {"http", "https"}
-        or host not in SUPPORTED_HOSTS
-        or parsed.username is not None
-        or parsed.password is not None
-        or port is not None
-    ):
-        raise NazurinError("Invalid Telegraph URL")
-
-    page_path = validate_page_path(parsed.path)
+    parsed = urlsplit(url)
+    host = parsed.hostname
+    assert host is not None
+    page_path = unquote(parsed.path).strip("/")
     source_url = f"https://{host}/{quote(page_path, safe='')}"
     return page_path, source_url
 

--- a/nazurin/sites/telegraph/interface.py
+++ b/nazurin/sites/telegraph/interface.py
@@ -1,5 +1,5 @@
 import re
-from urllib.parse import quote, unquote, urlsplit
+from urllib.parse import unquote, urlsplit
 
 from nazurin.models import Document
 from nazurin.sites import HandlerResult
@@ -8,19 +8,15 @@ from .api import Telegraph
 from .config import COLLECTION
 
 patterns = [
-    r"(?:^|,)(?P<url>(?i:https?://(?:telegra\.ph|graph\.org)/[\w%-]+))"
-    r"(?=,|$)",
+    r"(?P<url>(?i:https?://(?:telegra\.ph|graph\.org)/[\w%-]+))",
 ]
 
 
 def normalize_page_url(url: str) -> tuple[str, str]:
-    """Return a canonical page path and source URL."""
+    """Return the decoded page path and original source URL."""
     parsed = urlsplit(url)
-    host = parsed.hostname
-    assert host is not None
     page_path = unquote(parsed.path).strip("/")
-    source_url = f"https://{host}/{quote(page_path, safe='')}"
-    return page_path, source_url
+    return page_path, url
 
 
 async def handle(match: re.Match) -> HandlerResult:

--- a/nazurin/sites/telegraph/models.py
+++ b/nazurin/sites/telegraph/models.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path, PurePosixPath
+from urllib.parse import urlsplit
+
+import aiofiles
+import aiofiles.os
+from aiohttp import ClientError
+from PIL import Image as PILImage
+
+from nazurin.config import MAX_PARALLEL_DOWNLOAD, TEMP_DIR
+from nazurin.models import Caption, File, Illust, Image
+from nazurin.utils import Request, logger
+from nazurin.utils.decorators import async_wrap
+from nazurin.utils.exceptions import NazurinError
+from nazurin.utils.helpers import (
+    FILENAME_MAX_LENGTH,
+    ensure_existence_async,
+    sanitize_filename,
+)
+
+from .renderer import (
+    SAFE_MEDIA_SCHEMES,
+    ImageReference,
+    TelegraphRenderer,
+    collect_image_references,
+    safe_url,
+)
+
+TRUSTED_IMAGE_SUFFIXES = {
+    ".bmp",
+    ".gif",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".tif",
+    ".tiff",
+    ".webp",
+}
+PILLOW_EXTENSIONS = {
+    "BMP": ".bmp",
+    "GIF": ".gif",
+    "JPEG": ".jpg",
+    "PNG": ".png",
+    "TIFF": ".tiff",
+    "WEBP": ".webp",
+}
+PATH_HASH_LENGTH = 12
+
+
+def build_archive_name(page: dict) -> str:
+    """Build a readable storage directory name using project filename rules."""
+    title = sanitize_filename(page["title"]).strip(" .") or "Untitled"
+    path_hash = hashlib.sha256(page["path"].encode()).hexdigest()[:PATH_HASH_LENGTH]
+    suffix = f" ({path_hash})"
+    title = title[: FILENAME_MAX_LENGTH - len(suffix)].rstrip()
+    return title + suffix
+
+
+class TelegraphIllust(Illust):
+    """A Telegraph page prepared as a directory of local files."""
+
+    def __init__(
+        self,
+        raw_response: dict,
+        page: dict,
+        source_url: str,
+        destination: str,
+    ):
+        page_url = safe_url(page.get("url"), source_url, SAFE_MEDIA_SCHEMES)
+        page_url = page_url or source_url
+        content_json = json.dumps(
+            page["content"],
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        metadata = {
+            **page,
+            "canonical_path": page["path"],
+            "content_sha256": hashlib.sha256(content_json.encode()).hexdigest(),
+            "source_url": source_url,
+        }
+        caption = Caption(
+            {
+                "title": page["title"],
+                "author": page.get("author_name"),
+                "url": page_url,
+            },
+        )
+        self.article_file = File("article.html")
+        self.article_file.destination = destination
+        self.page_file = File("page.json")
+        self.page_file.destination = destination
+        super().__init__(
+            id=page["path"],
+            caption=caption,
+            metadata=metadata,
+            files=[self.article_file, self.page_file],
+        )
+        self.raw_response = raw_response
+        self.page = page
+        self.source_url = source_url
+        self.destination = destination
+        self.archive_name = build_archive_name(page)
+        self.image_references = collect_image_references(
+            page["content"],
+            page_url,
+        )
+        self.asset_failures: list[dict[str, str | int]] = []
+        self._workspace: str | None = None
+        self._prepared = False
+        self._prepare_lock = asyncio.Lock()
+
+    async def download(self, **_kwargs):
+        if await self._is_prepared():
+            return
+        async with self._prepare_lock:
+            if await self._is_prepared():
+                return
+            await self._reset_workspace()
+            try:
+                self._create_workspace()
+                await self._write_json()
+                image_paths = await self._download_images()
+                await self._write_article(image_paths)
+                self._prepared = True
+            except OSError as error:
+                await self._reset_workspace()
+                raise NazurinError("Failed to prepare Telegraph archive") from error
+            except Exception:
+                await self._reset_workspace()
+                raise
+
+    async def _is_prepared(self) -> bool:
+        if not self._prepared:
+            return False
+        for file in self.all_files:
+            if not await file.exists():
+                return False
+        return True
+
+    def _create_workspace(self):
+        try:
+            archive_dir = Path(TEMP_DIR, "Telegraph", self.archive_name)
+            archive_dir.mkdir(parents=True, exist_ok=True)
+            self._workspace = tempfile.mkdtemp(
+                prefix="work-",
+                dir=archive_dir,
+            )
+        except OSError as error:
+            raise NazurinError("Failed to create Telegraph workspace") from error
+        self.article_file.local_path = Path(self._workspace, "article.html")
+        self.page_file.local_path = Path(self._workspace, "page.json")
+
+    async def _write_json(self):
+        content = json.dumps(self.raw_response, ensure_ascii=False, indent=2) + "\n"
+        await self._atomic_write(self.page_file.path, content)
+
+    async def _write_article(self, image_paths: dict[int, str]):
+        renderer = TelegraphRenderer(self.page, self.source_url, image_paths)
+        await self._atomic_write(self.article_file.path, renderer.render())
+
+    async def _download_images(self) -> dict[int, str]:
+        downloadable = [
+            reference for reference in self.image_references if reference.url
+        ]
+        semaphore = asyncio.Semaphore(MAX_PARALLEL_DOWNLOAD)
+        async with Request() as session:
+
+            async def bounded_download(asset_index: int, reference: ImageReference):
+                async with semaphore:
+                    return await self._download_image(
+                        session,
+                        asset_index,
+                        reference,
+                    )
+
+            results = await asyncio.gather(
+                *[
+                    bounded_download(asset_index, reference)
+                    for asset_index, reference in enumerate(downloadable, start=1)
+                ],
+            )
+
+        self.images = [image for image, _ in results if image is not None]
+        return {
+            occurrence: PurePosixPath("assets", image.name).as_posix()
+            for image, occurrence in results
+            if image is not None
+        }
+
+    async def _download_image(
+        self,
+        session: Request,
+        asset_index: int,
+        reference: ImageReference,
+    ) -> tuple[Image | None, int]:
+        assert self._workspace is not None
+        assert reference.url is not None
+        suffix = Path(urlsplit(reference.url).path).suffix.lower()
+        suffix = suffix if suffix in TRUSTED_IMAGE_SUFFIXES else ".download"
+        name = f"{asset_index:03d}{suffix}"
+        local_path = Path(self._workspace, "assets", name)
+        image = Image(name, reference.url, local_path=local_path)
+        image.destination = str(PurePosixPath(self.destination, "assets"))
+        try:
+            await image.download(session)
+            detected_suffix = await async_wrap(self._detect_extension)(image.path)
+            final_name = f"{asset_index:03d}{detected_suffix}"
+            if final_name != image.name:
+                final_path = Path(self._workspace, "assets", final_name)
+                await aiofiles.os.replace(image.path, final_path)
+                image.name = final_name
+                image.local_path = final_path
+            return image, reference.occurrence
+        except (ClientError, asyncio.TimeoutError, NazurinError) as error:
+            if await aiofiles.os.path.exists(image.path):
+                await aiofiles.os.remove(image.path)
+            self.asset_failures.append(
+                {
+                    "occurrence": reference.occurrence,
+                    "url": reference.url,
+                    "error": str(error),
+                },
+            )
+            logger.warning(
+                "Failed to download Telegraph image {}: {}",
+                reference.url,
+                error,
+            )
+            return None, reference.occurrence
+
+    @staticmethod
+    def _detect_extension(path: str) -> str:
+        with PILImage.open(path) as image:
+            extension = PILLOW_EXTENSIONS.get(image.format or "")
+        if not extension:
+            raise NazurinError("Unsupported Telegraph image format")
+        return extension
+
+    @staticmethod
+    async def _atomic_write(path: str, content: str):
+        await ensure_existence_async(os.path.dirname(path))
+        temporary = path + ".tmp"
+        try:
+            async with aiofiles.open(temporary, "w", encoding="utf-8") as file:
+                await file.write(content)
+            await aiofiles.os.replace(temporary, path)
+        except OSError as error:
+            if await aiofiles.os.path.exists(temporary):
+                await aiofiles.os.remove(temporary)
+            raise NazurinError("Failed to write Telegraph archive") from error
+
+    async def _reset_workspace(self):
+        workspace = Path(self._workspace) if self._workspace else None
+        if workspace and await aiofiles.os.path.exists(workspace):
+            await async_wrap(shutil.rmtree)(workspace, ignore_errors=True)
+            for directory in (workspace.parent, workspace.parent.parent):
+                try:
+                    await aiofiles.os.rmdir(directory)
+                except OSError:
+                    break
+        self._workspace = None
+        self.article_file.local_path = None
+        self.page_file.local_path = None
+        self.images = []
+        self.asset_failures = []
+        self._prepared = False

--- a/nazurin/sites/telegraph/models.py
+++ b/nazurin/sites/telegraph/models.py
@@ -207,7 +207,8 @@ class TelegraphIllust(Illust):
         needs_suffix_detection = url_suffix not in TRUSTED_IMAGE_SUFFIXES
         suffix = ".download" if needs_suffix_detection else url_suffix
         name = f"{asset_index:03d}{suffix}"
-        local_path = Path(self._workspace, "assets", name)
+        assets_folder = Path(self._workspace, "assets")
+        local_path = assets_folder / name
         image = Image(name, reference.url, local_path=local_path)
         image.destination = str(PurePosixPath(self.destination, "assets"))
         try:
@@ -216,7 +217,7 @@ class TelegraphIllust(Illust):
                 detected_suffix = await self._detect_image_suffix(image.path)
                 if detected_suffix:
                     final_name = f"{asset_index:03d}{detected_suffix}"
-                    final_path = Path(self._workspace, "assets", final_name)
+                    final_path = assets_folder / final_name
                     try:
                         await aiofiles.os.replace(image.path, final_path)
                     except OSError as error:

--- a/nazurin/sites/telegraph/models.py
+++ b/nazurin/sites/telegraph/models.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import tempfile
 from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 import aiofiles
@@ -30,6 +31,9 @@ from .renderer import (
     TelegraphRenderer,
     collect_image_references,
 )
+
+if TYPE_CHECKING:
+    from .api import TelegraphPage
 
 TRUSTED_IMAGE_SUFFIXES = {
     ".bmp",
@@ -57,10 +61,10 @@ def build_path_hash(page_path: str) -> str:
     return hashlib.sha256(page_path.encode()).hexdigest()[:PATH_HASH_LENGTH]
 
 
-def build_archive_name(page: dict) -> str:
+def build_archive_name(page: TelegraphPage) -> str:
     """Build a readable storage directory name using project filename rules."""
-    title = sanitize_filename(page["title"]).strip(" .") or "Untitled"
-    path_hash = build_path_hash(page["path"])
+    title = sanitize_filename(page.title).strip(" .") or "Untitled"
+    path_hash = build_path_hash(page.path)
     suffix = f" ({path_hash})"
     title = title[: FILENAME_MAX_LENGTH - len(suffix)].rstrip()
     return title + suffix
@@ -72,26 +76,27 @@ class TelegraphIllust(Illust):
     def __init__(
         self,
         raw_response: dict,
-        page: dict,
+        page: TelegraphPage,
         source_url: str,
         destination: str,
     ):
-        page_url = page["url"]
+        raw_page = raw_response["result"]
+        page_url = page.url
         content_json = json.dumps(
-            page["content"],
+            raw_page.get("content", []),
             ensure_ascii=False,
             separators=(",", ":"),
             sort_keys=True,
         )
         metadata = {
-            **page,
+            **raw_page,
             "content_sha256": hashlib.sha256(content_json.encode()).hexdigest(),
             "source_url": source_url,
         }
         caption = Caption(
             {
-                "title": page["title"],
-                "author": page.get("author_name"),
+                "title": page.title,
+                "author": page.author_name,
                 "url": page_url,
             },
         )
@@ -100,7 +105,7 @@ class TelegraphIllust(Illust):
         self.page_file = File("page.json")
         self.page_file.destination = destination
         super().__init__(
-            id=page["path"],
+            id=page.path,
             caption=caption,
             metadata=metadata,
             files=[self.article_file, self.page_file],
@@ -110,7 +115,7 @@ class TelegraphIllust(Illust):
         self.source_url = source_url
         self.destination = destination
         self.image_references = collect_image_references(
-            page["content"],
+            page.content,
             page_url,
         )
         self._workspace: str | None = None

--- a/nazurin/sites/telegraph/models.py
+++ b/nazurin/sites/telegraph/models.py
@@ -12,7 +12,6 @@ from urllib.parse import urlsplit
 import aiofiles
 import aiofiles.os
 from aiohttp import ClientError
-from PIL import Image as PILImage
 
 from nazurin.config import MAX_PARALLEL_DOWNLOAD, TEMP_DIR
 from nazurin.models import Caption, File, Illust, Image
@@ -40,14 +39,6 @@ TRUSTED_IMAGE_SUFFIXES = {
     ".tif",
     ".tiff",
     ".webp",
-}
-PILLOW_EXTENSIONS = {
-    "BMP": ".bmp",
-    "GIF": ".gif",
-    "JPEG": ".jpg",
-    "PNG": ".png",
-    "TIFF": ".tiff",
-    "WEBP": ".webp",
 }
 PATH_HASH_LENGTH = 12
 
@@ -211,13 +202,6 @@ class TelegraphIllust(Illust):
         image.destination = str(PurePosixPath(self.destination, "assets"))
         try:
             await image.download(session)
-            detected_suffix = await async_wrap(self._detect_extension)(image.path)
-            final_name = f"{asset_index:03d}{detected_suffix}"
-            if final_name != image.name:
-                final_path = Path(self._workspace, "assets", final_name)
-                await aiofiles.os.replace(image.path, final_path)
-                image.name = final_name
-                image.local_path = final_path
             return image, reference.occurrence
         except (ClientError, asyncio.TimeoutError, NazurinError) as error:
             if await aiofiles.os.path.exists(image.path):
@@ -228,14 +212,6 @@ class TelegraphIllust(Illust):
                 error,
             )
             return None, reference.occurrence
-
-    @staticmethod
-    def _detect_extension(path: str) -> str:
-        with PILImage.open(path) as image:
-            extension = PILLOW_EXTENSIONS.get(image.format or "")
-        if not extension:
-            raise NazurinError("Unsupported Telegraph image format")
-        return extension
 
     @staticmethod
     async def _atomic_write(path: str, content: str):

--- a/nazurin/sites/telegraph/models.py
+++ b/nazurin/sites/telegraph/models.py
@@ -26,11 +26,9 @@ from nazurin.utils.helpers import (
 )
 
 from .renderer import (
-    SAFE_MEDIA_SCHEMES,
     ImageReference,
     TelegraphRenderer,
     collect_image_references,
-    safe_url,
 )
 
 TRUSTED_IMAGE_SUFFIXES = {
@@ -78,8 +76,7 @@ class TelegraphIllust(Illust):
         source_url: str,
         destination: str,
     ):
-        page_url = safe_url(page.get("url"), source_url, SAFE_MEDIA_SCHEMES)
-        page_url = page_url or source_url
+        page_url = page["url"]
         content_json = json.dumps(
             page["content"],
             ensure_ascii=False,

--- a/nazurin/sites/telegraph/models.py
+++ b/nazurin/sites/telegraph/models.py
@@ -12,7 +12,7 @@ from urllib.parse import urlsplit
 
 import aiofiles
 import aiofiles.os
-from aiohttp import ClientError
+from aiohttp import ClientError, ClientSession
 from PIL import Image as PILImage
 
 from nazurin.config import MAX_PARALLEL_DOWNLOAD, TEMP_DIR
@@ -201,7 +201,7 @@ class TelegraphIllust(Illust):
 
     async def _download_image(
         self,
-        session: Request,
+        session: ClientSession,
         asset_index: int,
         reference: ImageReference,
     ) -> tuple[Image | None, int]:

--- a/nazurin/sites/telegraph/models.py
+++ b/nazurin/sites/telegraph/models.py
@@ -12,6 +12,7 @@ from urllib.parse import urlsplit
 import aiofiles
 import aiofiles.os
 from aiohttp import ClientError
+from PIL import Image as PILImage
 
 from nazurin.config import MAX_PARALLEL_DOWNLOAD, TEMP_DIR
 from nazurin.models import Caption, File, Illust, Image
@@ -39,6 +40,14 @@ TRUSTED_IMAGE_SUFFIXES = {
     ".tif",
     ".tiff",
     ".webp",
+}
+PILLOW_FORMAT_SUFFIXES = {
+    "BMP": ".bmp",
+    "GIF": ".gif",
+    "JPEG": ".jpg",
+    "PNG": ".png",
+    "TIFF": ".tiff",
+    "WEBP": ".webp",
 }
 PATH_HASH_LENGTH = 12
 
@@ -194,14 +203,39 @@ class TelegraphIllust(Illust):
     ) -> tuple[Image | None, int]:
         assert self._workspace is not None
         assert reference.url is not None
-        suffix = Path(urlsplit(reference.url).path).suffix.lower()
-        suffix = suffix if suffix in TRUSTED_IMAGE_SUFFIXES else ".download"
+        url_suffix = Path(urlsplit(reference.url).path).suffix.lower()
+        needs_suffix_detection = url_suffix not in TRUSTED_IMAGE_SUFFIXES
+        suffix = ".download" if needs_suffix_detection else url_suffix
         name = f"{asset_index:03d}{suffix}"
         local_path = Path(self._workspace, "assets", name)
         image = Image(name, reference.url, local_path=local_path)
         image.destination = str(PurePosixPath(self.destination, "assets"))
         try:
             await image.download(session)
+            if needs_suffix_detection:
+                detected_suffix = await self._detect_image_suffix(image.path)
+                if detected_suffix:
+                    final_name = f"{asset_index:03d}{detected_suffix}"
+                    final_path = Path(self._workspace, "assets", final_name)
+                    try:
+                        await aiofiles.os.replace(image.path, final_path)
+                    except OSError as error:
+                        if not await aiofiles.os.path.exists(image.path):
+                            raise
+                        logger.warning(
+                            "Failed to rename Telegraph image {}: {}",
+                            reference.url,
+                            error,
+                        )
+                    else:
+                        image.name = final_name
+                        image.local_path = final_path
+                else:
+                    logger.warning(
+                        "Failed to detect Telegraph image format for {}, keeping {}",
+                        reference.url,
+                        image.name,
+                    )
             return image, reference.occurrence
         except (ClientError, asyncio.TimeoutError, NazurinError) as error:
             if await aiofiles.os.path.exists(image.path):
@@ -212,6 +246,15 @@ class TelegraphIllust(Illust):
                 error,
             )
             return None, reference.occurrence
+
+    @staticmethod
+    @async_wrap
+    def _detect_image_suffix(path: str | os.PathLike) -> str | None:
+        try:
+            with PILImage.open(path) as image:
+                return PILLOW_FORMAT_SUFFIXES.get(image.format or "")
+        except OSError:
+            return None
 
     @staticmethod
     async def _atomic_write(path: str, content: str):

--- a/nazurin/sites/telegraph/models.py
+++ b/nazurin/sites/telegraph/models.py
@@ -112,7 +112,6 @@ class TelegraphIllust(Illust):
         self.page = page
         self.source_url = source_url
         self.destination = destination
-        self.archive_name = build_archive_name(page)
         self.image_references = collect_image_references(
             page["content"],
             page_url,
@@ -151,11 +150,11 @@ class TelegraphIllust(Illust):
 
     def _create_workspace(self):
         try:
-            archive_dir = Path(TEMP_DIR, "Telegraph", self.archive_name)
-            archive_dir.mkdir(parents=True, exist_ok=True)
+            workspace_root = Path(TEMP_DIR, "Telegraph")
+            workspace_root.mkdir(parents=True, exist_ok=True)
             self._workspace = tempfile.mkdtemp(
                 prefix="work-",
-                dir=archive_dir,
+                dir=workspace_root,
             )
         except OSError as error:
             raise NazurinError("Failed to create Telegraph workspace") from error
@@ -258,11 +257,6 @@ class TelegraphIllust(Illust):
         workspace = Path(self._workspace) if self._workspace else None
         if workspace and await aiofiles.os.path.exists(workspace):
             await async_wrap(shutil.rmtree)(workspace, ignore_errors=True)
-            for directory in (workspace.parent, workspace.parent.parent):
-                try:
-                    await aiofiles.os.rmdir(directory)
-                except OSError:
-                    break
         self._workspace = None
         self.article_file.local_path = None
         self.page_file.local_path = None

--- a/nazurin/sites/telegraph/models.py
+++ b/nazurin/sites/telegraph/models.py
@@ -112,7 +112,6 @@ class TelegraphIllust(Illust):
         )
         self.raw_response = raw_response
         self.page = page
-        self.source_url = source_url
         self.destination = destination
         self.image_references = collect_image_references(
             page.content,
@@ -160,15 +159,15 @@ class TelegraphIllust(Illust):
             )
         except OSError as error:
             raise NazurinError("Failed to create Telegraph workspace") from error
-        self.article_file.local_path = Path(self._workspace, "article.html")
-        self.page_file.local_path = Path(self._workspace, "page.json")
+        self.article_file.local_dir = self._workspace
+        self.page_file.local_dir = self._workspace
 
     async def _write_json(self):
         content = json.dumps(self.raw_response, ensure_ascii=False, indent=2) + "\n"
         await self._atomic_write(self.page_file.path, content)
 
     async def _write_article(self, image_paths: dict[int, str]):
-        renderer = TelegraphRenderer(self.page, self.source_url, image_paths)
+        renderer = TelegraphRenderer(self.page, image_paths)
         await self._atomic_write(self.article_file.path, renderer.render())
 
     async def _download_images(self) -> dict[int, str]:
@@ -213,8 +212,8 @@ class TelegraphIllust(Illust):
         suffix = ".download" if needs_suffix_detection else url_suffix
         name = f"{asset_index:03d}{suffix}"
         assets_folder = Path(self._workspace, "assets")
-        local_path = assets_folder / name
-        image = Image(name, reference.url, local_path=local_path)
+        image = Image(name, reference.url)
+        image.local_dir = assets_folder
         image.destination = str(PurePosixPath(self.destination, "assets"))
         try:
             await image.download(session)
@@ -235,7 +234,6 @@ class TelegraphIllust(Illust):
                         )
                     else:
                         image.name = final_name
-                        image.local_path = final_path
                 else:
                     logger.warning(
                         "Failed to detect Telegraph image format for {}, keeping {}",
@@ -280,7 +278,7 @@ class TelegraphIllust(Illust):
         if workspace and await aiofiles.os.path.exists(workspace):
             await async_wrap(shutil.rmtree)(workspace, ignore_errors=True)
         self._workspace = None
-        self.article_file.local_path = None
-        self.page_file.local_path = None
+        self.article_file.local_dir = TEMP_DIR
+        self.page_file.local_dir = TEMP_DIR
         self.images = []
         self._prepared = False

--- a/nazurin/sites/telegraph/models.py
+++ b/nazurin/sites/telegraph/models.py
@@ -54,10 +54,15 @@ PILLOW_EXTENSIONS = {
 PATH_HASH_LENGTH = 12
 
 
+def build_path_hash(page_path: str) -> str:
+    """Build a stable short hash for a Telegraph page path."""
+    return hashlib.sha256(page_path.encode()).hexdigest()[:PATH_HASH_LENGTH]
+
+
 def build_archive_name(page: dict) -> str:
     """Build a readable storage directory name using project filename rules."""
     title = sanitize_filename(page["title"]).strip(" .") or "Untitled"
-    path_hash = hashlib.sha256(page["path"].encode()).hexdigest()[:PATH_HASH_LENGTH]
+    path_hash = build_path_hash(page["path"])
     suffix = f" ({path_hash})"
     title = title[: FILENAME_MAX_LENGTH - len(suffix)].rstrip()
     return title + suffix
@@ -83,7 +88,6 @@ class TelegraphIllust(Illust):
         )
         metadata = {
             **page,
-            "canonical_path": page["path"],
             "content_sha256": hashlib.sha256(content_json.encode()).hexdigest(),
             "source_url": source_url,
         }
@@ -113,7 +117,6 @@ class TelegraphIllust(Illust):
             page["content"],
             page_url,
         )
-        self.asset_failures: list[dict[str, str | int]] = []
         self._workspace: str | None = None
         self._prepared = False
         self._prepare_lock = asyncio.Lock()
@@ -223,13 +226,6 @@ class TelegraphIllust(Illust):
         except (ClientError, asyncio.TimeoutError, NazurinError) as error:
             if await aiofiles.os.path.exists(image.path):
                 await aiofiles.os.remove(image.path)
-            self.asset_failures.append(
-                {
-                    "occurrence": reference.occurrence,
-                    "url": reference.url,
-                    "error": str(error),
-                },
-            )
             logger.warning(
                 "Failed to download Telegraph image {}: {}",
                 reference.url,
@@ -271,5 +267,4 @@ class TelegraphIllust(Illust):
         self.article_file.local_path = None
         self.page_file.local_path = None
         self.images = []
-        self.asset_failures = []
         self._prepared = False

--- a/nazurin/sites/telegraph/renderer.py
+++ b/nazurin/sites/telegraph/renderer.py
@@ -123,6 +123,7 @@ class TelegraphRenderer:
       max-width: 46rem;
       padding: 0 1rem;
     }}
+    a {{ color: inherit; }}
     img, video {{ height: auto; max-width: 100%; }}
     figure {{ margin: 1.5rem 0; }}
     figcaption {{ color: #666; font-size: 0.9rem; }}
@@ -132,13 +133,14 @@ class TelegraphRenderer:
       padding-left: 1rem;
     }}
     pre {{ background: #f5f5f5; overflow-x: auto; padding: 1rem; }}
-    .author {{ color: #79828B; }}
+    .title {{ font-size: 32px; line-height: 34px; margin-block: 12px; }}
+    .author {{ color: #79828B; font-size: 15px; margin-block: 12px; }}
     .source, .embed {{ color: #666; }}
   </style>
 </head>
 <body>
   <article>
-    <h1>{title}</h1>
+    <h1 class="title">{title}</h1>
     {author}
     {content}
     {source}

--- a/nazurin/sites/telegraph/renderer.py
+++ b/nazurin/sites/telegraph/renderer.py
@@ -191,17 +191,19 @@ class TelegraphRenderer:
             return rendered_children
 
         tag = TAG_ALIASES.get(tag, tag)
-        if tag in DIRECT_TAGS:
-            return f"<{tag}>{rendered_children}</{tag}>"
-        if tag in VOID_TAGS:
-            return f"<{tag}>"
-        if tag == "a":
-            return self._render_anchor(node, rendered_children)
-        if tag == "img":
-            return self._render_image(node)
-        if tag in {"iframe", "video"}:
-            return self._render_embed(node, tag, rendered_children)
-        return rendered_children
+        match tag:
+            case _ if tag in DIRECT_TAGS:
+                return f"<{tag}>{rendered_children}</{tag}>"
+            case _ if tag in VOID_TAGS:
+                return f"<{tag}/>"
+            case "a":
+                return self._render_anchor(node, rendered_children)
+            case "img":
+                return self._render_image(node)
+            case "iframe" | "video":
+                return self._render_embed(node, tag, rendered_children)
+            case _:
+                return rendered_children
 
     def _attrs(self, node: dict) -> dict:
         attrs = node.get("attrs")

--- a/nazurin/sites/telegraph/renderer.py
+++ b/nazurin/sites/telegraph/renderer.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from html import escape
-from typing import Any
+from typing import TYPE_CHECKING
 from urllib.parse import urljoin, urlsplit
+
+if TYPE_CHECKING:
+    from .api import TelegraphNode, TelegraphNodeElement, TelegraphPage
 
 SAFE_LINK_SCHEMES = {"http", "https", "mailto"}
 SAFE_MEDIA_SCHEMES = {"http", "https"}
@@ -59,18 +62,20 @@ def safe_url(value: object, base_url: str, schemes: set[str]) -> str | None:
     return resolved
 
 
-def collect_image_references(nodes: list[Any], base_url: str) -> list[ImageReference]:
+def collect_image_references(
+    nodes: list[TelegraphNode],
+    base_url: str,
+) -> list[ImageReference]:
     """Collect image nodes in document order."""
     references: list[ImageReference] = []
     occurrence = 0
 
-    def visit(node: object):
+    def visit(node: TelegraphNode):
         nonlocal occurrence
-        if not isinstance(node, dict):
+        if isinstance(node, str):
             return
-        tag = node.get("tag")
-        attrs = node.get("attrs") if isinstance(node.get("attrs"), dict) else {}
-        if tag == "img":
+        attrs = node.attrs or {}
+        if node.tag == "img":
             occurrence += 1
             url = safe_url(attrs.get("src"), base_url, SAFE_MEDIA_SCHEMES)
             references.append(
@@ -79,10 +84,8 @@ def collect_image_references(nodes: list[Any], base_url: str) -> list[ImageRefer
                     url=url,
                 ),
             )
-        children = node.get("children")
-        if isinstance(children, list):
-            for child in children:
-                visit(child)
+        for child in node.children or []:
+            visit(child)
 
     for node in nodes:
         visit(node)
@@ -92,7 +95,7 @@ def collect_image_references(nodes: list[Any], base_url: str) -> list[ImageRefer
 class TelegraphRenderer:
     def __init__(
         self,
-        page: dict,
+        page: TelegraphPage,
         source_url: str,
         image_paths: dict[int, str] | None = None,
     ):
@@ -103,10 +106,10 @@ class TelegraphRenderer:
 
     def render(self) -> str:
         self._image_occurrence = 0
-        title = escape(self.page["title"], quote=False)
+        title = escape(self.page.title, quote=False)
         author = self._render_author()
         source = self._render_source()
-        content = self._render_nodes(self.page["content"])
+        content = self._render_nodes(self.page.content)
         return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -147,12 +150,12 @@ class TelegraphRenderer:
 """
 
     def _render_author(self) -> str:
-        author_name = self.page.get("author_name")
-        if not isinstance(author_name, str) or not author_name:
+        author_name = self.page.author_name
+        if not author_name:
             return ""
         name = escape(author_name, quote=False)
         author_url = safe_url(
-            self.page.get("author_url"),
+            self.page.author_url,
             self.source_url,
             SAFE_LINK_SCHEMES,
         )
@@ -174,20 +177,15 @@ class TelegraphRenderer:
             "Original page</a></p>"
         )
 
-    def _render_nodes(self, nodes: list[Any]) -> str:
+    def _render_nodes(self, nodes: list[TelegraphNode]) -> str:
         return "".join(self._render_node(node) for node in nodes)
 
-    def _render_node(self, node: object) -> str:  # noqa: PLR0911
+    def _render_node(self, node: TelegraphNode) -> str:  # noqa: PLR0911
         if isinstance(node, str):
             return escape(node, quote=False)
-        if not isinstance(node, dict):
-            return ""
 
-        tag = node.get("tag")
-        children = node.get("children")
-        rendered_children = (
-            self._render_nodes(children) if isinstance(children, list) else ""
-        )
+        tag = node.tag
+        rendered_children = self._render_nodes(node.children or [])
 
         tag = TAG_ALIASES.get(tag, tag)
         match tag:
@@ -204,11 +202,11 @@ class TelegraphRenderer:
             case _:
                 return rendered_children
 
-    def _attrs(self, node: dict) -> dict:
-        attrs = node.get("attrs")
-        return attrs if isinstance(attrs, dict) else {}
+    @staticmethod
+    def _attrs(node: TelegraphNodeElement) -> dict[str, str]:
+        return node.attrs or {}
 
-    def _render_anchor(self, node: dict, children: str) -> str:
+    def _render_anchor(self, node: TelegraphNodeElement, children: str) -> str:
         href = safe_url(
             self._attrs(node).get("href"),
             self.source_url,
@@ -220,7 +218,7 @@ class TelegraphRenderer:
         escaped_href = escape(href, quote=True)
         return f'<a href="{escaped_href}" rel="noopener noreferrer">{label}</a>'
 
-    def _render_image(self, node: dict) -> str:
+    def _render_image(self, node: TelegraphNodeElement) -> str:
         self._image_occurrence += 1
         local_path = self.image_paths.get(self._image_occurrence)
         if local_path:
@@ -238,7 +236,12 @@ class TelegraphRenderer:
             f'<a class="image-link" href="{href}" rel="noopener noreferrer">Image</a>'
         )
 
-    def _render_embed(self, node: dict, tag: str, children: str) -> str:
+    def _render_embed(
+        self,
+        node: TelegraphNodeElement,
+        tag: str,
+        children: str,
+    ) -> str:
         source = safe_url(
             self._attrs(node).get("src"),
             self.source_url,

--- a/nazurin/sites/telegraph/renderer.py
+++ b/nazurin/sites/telegraph/renderer.py
@@ -131,6 +131,7 @@ class TelegraphRenderer:
       padding-left: 1rem;
     }}
     pre {{ background: #f5f5f5; overflow-x: auto; padding: 1rem; }}
+    .author {{ color: #79828B; }}
     .source, .embed {{ color: #666; }}
   </style>
 </head>

--- a/nazurin/sites/telegraph/renderer.py
+++ b/nazurin/sites/telegraph/renderer.py
@@ -187,8 +187,6 @@ class TelegraphRenderer:
         rendered_children = (
             self._render_nodes(children) if isinstance(children, list) else ""
         )
-        if not isinstance(tag, str):
-            return rendered_children
 
         tag = TAG_ALIASES.get(tag, tag)
         match tag:

--- a/nazurin/sites/telegraph/renderer.py
+++ b/nazurin/sites/telegraph/renderer.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html import escape
+from typing import Any
+from urllib.parse import urljoin, urlsplit
+
+SAFE_LINK_SCHEMES = {"http", "https", "mailto"}
+SAFE_MEDIA_SCHEMES = {"http", "https"}
+
+DIRECT_TAGS = {
+    "aside",
+    "blockquote",
+    "code",
+    "em",
+    "figcaption",
+    "figure",
+    "h3",
+    "h4",
+    "li",
+    "ol",
+    "p",
+    "pre",
+    "s",
+    "strong",
+    "u",
+    "ul",
+}
+TAG_ALIASES = {"b": "strong", "i": "em"}
+VOID_TAGS = {"br", "hr"}
+
+
+@dataclass(frozen=True)
+class ImageReference:
+    occurrence: int
+    url: str | None
+
+
+def safe_url(value: object, base_url: str, schemes: set[str]) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    resolved = urljoin(base_url, value.strip())
+    try:
+        parsed = urlsplit(resolved)
+        port = parsed.port
+    except ValueError:
+        return None
+    scheme = parsed.scheme.lower()
+    if scheme == "mailto":
+        return resolved if scheme in schemes and bool(parsed.path) else None
+    if (
+        scheme not in schemes
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+    ):
+        return None
+    return resolved
+
+
+def collect_image_references(nodes: list[Any], base_url: str) -> list[ImageReference]:
+    """Collect image nodes in document order."""
+    references: list[ImageReference] = []
+    occurrence = 0
+
+    def visit(node: object):
+        nonlocal occurrence
+        if not isinstance(node, dict):
+            return
+        tag = node.get("tag")
+        attrs = node.get("attrs") if isinstance(node.get("attrs"), dict) else {}
+        if tag == "img":
+            occurrence += 1
+            url = safe_url(attrs.get("src"), base_url, SAFE_MEDIA_SCHEMES)
+            references.append(
+                ImageReference(
+                    occurrence=occurrence,
+                    url=url,
+                ),
+            )
+        children = node.get("children")
+        if isinstance(children, list):
+            for child in children:
+                visit(child)
+
+    for node in nodes:
+        visit(node)
+    return references
+
+
+class TelegraphRenderer:
+    def __init__(
+        self,
+        page: dict,
+        source_url: str,
+        image_paths: dict[int, str] | None = None,
+    ):
+        self.page = page
+        self.source_url = source_url
+        self.image_paths = image_paths or {}
+        self._image_occurrence = 0
+
+    def render(self) -> str:
+        self._image_occurrence = 0
+        title = escape(self.page["title"], quote=False)
+        author = self._render_author()
+        source = self._render_source()
+        content = self._render_nodes(self.page["content"])
+        return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{title}</title>
+  <style>
+    body {{
+      color: #222;
+      font-family: system-ui, sans-serif;
+      line-height: 1.65;
+      margin: 2rem auto;
+      max-width: 46rem;
+      padding: 0 1rem;
+    }}
+    img, video {{ height: auto; max-width: 100%; }}
+    figure {{ margin: 1.5rem 0; }}
+    figcaption {{ color: #666; font-size: 0.9rem; }}
+    blockquote {{
+      border-left: 0.25rem solid #ccc;
+      margin-left: 0;
+      padding-left: 1rem;
+    }}
+    pre {{ background: #f5f5f5; overflow-x: auto; padding: 1rem; }}
+    .source, .embed {{ color: #666; }}
+  </style>
+</head>
+<body>
+  <article>
+    <h1>{title}</h1>
+    {author}
+    {content}
+    {source}
+  </article>
+</body>
+</html>
+"""
+
+    def _render_author(self) -> str:
+        author_name = self.page.get("author_name")
+        if not isinstance(author_name, str) or not author_name:
+            return ""
+        name = escape(author_name, quote=False)
+        author_url = safe_url(
+            self.page.get("author_url"),
+            self.source_url,
+            SAFE_LINK_SCHEMES,
+        )
+        if author_url:
+            href = escape(author_url, quote=True)
+            return (
+                f'<p class="author">By <a href="{href}" '
+                f'rel="noopener noreferrer">{name}</a></p>'
+            )
+        return f'<p class="author">By {name}</p>'
+
+    def _render_source(self) -> str:
+        source_url = safe_url(self.source_url, self.source_url, SAFE_MEDIA_SCHEMES)
+        if not source_url:
+            return ""
+        href = escape(source_url, quote=True)
+        return (
+            f'<p class="source"><a href="{href}" rel="noopener noreferrer">'
+            "Original page</a></p>"
+        )
+
+    def _render_nodes(self, nodes: list[Any]) -> str:
+        return "".join(self._render_node(node) for node in nodes)
+
+    def _render_node(self, node: object) -> str:  # noqa: PLR0911
+        if isinstance(node, str):
+            return escape(node, quote=False)
+        if not isinstance(node, dict):
+            return ""
+
+        tag = node.get("tag")
+        children = node.get("children")
+        rendered_children = (
+            self._render_nodes(children) if isinstance(children, list) else ""
+        )
+        if not isinstance(tag, str):
+            return rendered_children
+
+        tag = TAG_ALIASES.get(tag, tag)
+        if tag in DIRECT_TAGS:
+            return f"<{tag}>{rendered_children}</{tag}>"
+        if tag in VOID_TAGS:
+            return f"<{tag}>"
+        if tag == "a":
+            return self._render_anchor(node, rendered_children)
+        if tag == "img":
+            return self._render_image(node)
+        if tag in {"iframe", "video"}:
+            return self._render_embed(node, tag, rendered_children)
+        return rendered_children
+
+    def _attrs(self, node: dict) -> dict:
+        attrs = node.get("attrs")
+        return attrs if isinstance(attrs, dict) else {}
+
+    def _render_anchor(self, node: dict, children: str) -> str:
+        href = safe_url(
+            self._attrs(node).get("href"),
+            self.source_url,
+            SAFE_LINK_SCHEMES,
+        )
+        if not href:
+            return children
+        label = children or escape(href, quote=False)
+        escaped_href = escape(href, quote=True)
+        return f'<a href="{escaped_href}" rel="noopener noreferrer">{label}</a>'
+
+    def _render_image(self, node: dict) -> str:
+        self._image_occurrence += 1
+        local_path = self.image_paths.get(self._image_occurrence)
+        if local_path:
+            return f'<img src="{escape(local_path, quote=True)}" alt="">'
+
+        source = safe_url(
+            self._attrs(node).get("src"),
+            self.source_url,
+            SAFE_MEDIA_SCHEMES,
+        )
+        if not source:
+            return ""
+        href = escape(source, quote=True)
+        return (
+            f'<a class="image-link" href="{href}" rel="noopener noreferrer">Image</a>'
+        )
+
+    def _render_embed(self, node: dict, tag: str, children: str) -> str:
+        source = safe_url(
+            self._attrs(node).get("src"),
+            self.source_url,
+            SAFE_MEDIA_SCHEMES,
+        )
+        link = ""
+        if source:
+            href = escape(source, quote=True)
+            label = "Video" if tag == "video" else "Embedded content"
+            link = f'<a href="{href}" rel="noopener noreferrer">{label}</a>'
+        content = link + children
+        return f'<span class="embed">{content}</span>' if content else ""

--- a/nazurin/sites/telegraph/renderer.py
+++ b/nazurin/sites/telegraph/renderer.py
@@ -96,11 +96,9 @@ class TelegraphRenderer:
     def __init__(
         self,
         page: TelegraphPage,
-        source_url: str,
         image_paths: dict[int, str] | None = None,
     ):
         self.page = page
-        self.source_url = source_url
         self.image_paths = image_paths or {}
         self._image_occurrence = 0
 
@@ -156,7 +154,7 @@ class TelegraphRenderer:
         name = escape(author_name, quote=False)
         author_url = safe_url(
             self.page.author_url,
-            self.source_url,
+            self.page.url,
             SAFE_LINK_SCHEMES,
         )
         if author_url:
@@ -168,10 +166,7 @@ class TelegraphRenderer:
         return f'<p class="author">By {name}</p>'
 
     def _render_source(self) -> str:
-        source_url = safe_url(self.source_url, self.source_url, SAFE_MEDIA_SCHEMES)
-        if not source_url:
-            return ""
-        href = escape(source_url, quote=True)
+        href = escape(self.page.url, quote=True)
         return (
             f'<p class="source"><a href="{href}" rel="noopener noreferrer">'
             "Original page</a></p>"
@@ -209,7 +204,7 @@ class TelegraphRenderer:
     def _render_anchor(self, node: TelegraphNodeElement, children: str) -> str:
         href = safe_url(
             self._attrs(node).get("href"),
-            self.source_url,
+            self.page.url,
             SAFE_LINK_SCHEMES,
         )
         if not href:
@@ -226,7 +221,7 @@ class TelegraphRenderer:
 
         source = safe_url(
             self._attrs(node).get("src"),
-            self.source_url,
+            self.page.url,
             SAFE_MEDIA_SCHEMES,
         )
         if not source:
@@ -244,7 +239,7 @@ class TelegraphRenderer:
     ) -> str:
         source = safe_url(
             self._attrs(node).get("src"),
-            self.source_url,
+            self.page.url,
             SAFE_MEDIA_SCHEMES,
         )
         link = ""


### PR DESCRIPTION
Add Telegraph support (`telegra.ph` and `graph.org`). This site plugin fetches Telegraph pages through the official Telegraph API, saves Telegraph page data (title, original URL, etc.) in JSON, downloads the original page images (mostly WebP), and then renders each page as an HTML file.

```
Telegraph/
└── <sanitised-title> (<path-hash>)/
    ├── article.html
    ├── page.json
    └── assets/
        ├── 001.webp
        ├── 002.webp
        └── ...
```
Changes:
* Added `nazurin/sites/telegraph/`, including:
  * `interface.py` for matching and normalising Telegraph URLs.
  * `api.py` for retrieving page data through the official Telegraph API.
  * `models.py` for preparing page archives and downloading images.
  * `renderer.py` for converting Telegraph content into HTML.
  * `config.py` and `__init__.py` for site configuration and plugin registration.
* Updated `nazurin/models/file.py` to support an optional custom local path, allowing each Telegraph page to use its own temporary workspace without changing the default behaviour of existing sites.
* Updated `.env.example` and other doc files to add Telegraph configuration and usage information.

Tested with multiple Telegraph links using Docker, with both Local and Mega storage backends and the MongoDB.
