### PR TITLE
fix(bluesky): fail to resolve file extension from URL

### DIFF
--- a/nazurin/sites/bluesky/api.py
+++ b/nazurin/sites/bluesky/api.py
@@ -1,4 +1,6 @@
 import os
+from mimetypes import guess_extension
+from urllib.parse import urlparse
 
 from nazurin.models import Caption, Illust, Image
 from nazurin.utils import Request
@@ -14,7 +16,7 @@ class Bluesky:
     async def resolve_handle(self, handle: str):
         """
         Get the DID from handle.
-        https://www.docs.bsky.app/docs/api/com-atproto-identity-resolve-handle
+        https://endpoints.bsky.app/#bluesky-app/tag/comatprotoidentity/GET/xrpc/com.atproto.identity.resolveHandle
         """
         api = "https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle"
         async with (
@@ -34,7 +36,7 @@ class Bluesky:
     async def get_post_thread(self, uri: str, depth: int, parent_height: int):
         """
         Get posts in a thread.
-        https://www.docs.bsky.app/docs/api/app-bsky-feed-get-post-thread
+        https://endpoints.bsky.app/#bluesky-app/tag/appbskyfeed/GET/xrpc/app.bsky.feed.getPostThread
         """
         api = "https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread"
         params = {"uri": uri, "depth": depth, "parentHeight": parent_height}
@@ -70,11 +72,17 @@ class Bluesky:
         embed_images = item["embed"]["images"]
         if not embed_images or len(embed_images) == 0:
             raise NazurinError("No image found")
+        image_mimetypes = Bluesky.build_mimetypes_map(item)
         imgs = []
         for index, pic in enumerate(embed_images):
             url = pic["fullsize"]
             thumbnail = pic["thumb"]
-            destination, filename = Bluesky.get_storage_dest(item, pic, index)
+            destination, filename = Bluesky.get_storage_dest(
+                item,
+                pic,
+                image_mimetypes,
+                index,
+            )
             imgs.append(
                 Image(
                     filename,
@@ -86,15 +94,41 @@ class Bluesky:
         return imgs
 
     @staticmethod
-    def get_storage_dest(item: dict, pic: dict, index: int = 0) -> tuple[str, str]:
+    def build_mimetypes_map(item: dict) -> dict[str, str]:
+        """Map record image blob IDs to MIME types."""
+        try:
+            return {
+                image["image"]["ref"]["$link"]: image["image"]["mimeType"]
+                for image in item["record"]["embed"]["images"]
+            }
+        except (KeyError, TypeError) as error:
+            raise NazurinError("Invalid image MIME type metadata") from error
+
+    @staticmethod
+    def get_storage_dest(
+        item: dict,
+        pic: dict,
+        image_mimetypes: dict[str, str],
+        index: int = 0,
+    ) -> tuple[str, str]:
         """
         Format destination and filename.
         """
 
         url = pic["fullsize"]
         created_at = fromisoformat(item["record"]["createdAt"])
-        basename = os.path.basename(url)
-        filename, extension = basename.split("@")
+        basename = os.path.basename(urlparse(url).path)
+        try:
+            mimetype = image_mimetypes[basename]
+        except KeyError as error:
+            raise NazurinError(
+                f"No image MIME type found for blob: {basename}",
+            ) from error
+        extension = guess_extension(mimetype)
+        if extension is None:
+            raise NazurinError(f"Unsupported image MIME type: {mimetype}")
+        extension = extension.lstrip(".")
+        filename = basename
         context = {
             "rkey": item["uri"].split("/")[-1],
             "uri": item["uri"],


### PR DESCRIPTION
## Background

Bluesky previously returned `fullsize` CDN URLs with the image format appended after `@`, for example:

```text
.../bafkrei...@jpeg
```

Nazurin derived the downloaded filename extension by splitting that final URL segment on `@`.

Bluesky now returns extensionless URLs such as: `https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:e4wcdw3pzqnkz5cvxyhjcfhc/bafkreiesz5jfnvdgdmx5si6td7mtfw7bocuyqar7jmubhbsgxoaad3krfy`

The current `basename.split("@")` call therefore raises `ValueError` because there is no separator or extension in the URL. The response still includes the authoritative source MIME type at `record.embed.images[*].image.mimeType`, e.g.:

```json
"record": {
    "$type": "app.bsky.feed.post",
    "embed": {
        "$type": "app.bsky.embed.images",
        "images": [
            {
                "image": {
                    "$type": "blob",
                    "ref": {
                        "$link": "bafkreiesz5jfnvdgdmx5si6td7mtfw7bocuyqar7jmubhbsgxoaad3krfy"
                    },
                    "mimeType": "image/jpeg",
                    "size": 242346
                }
            }
        ]
    },
},
"embed": {
    "images": [
        {
            "thumb": "https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:e4wcdw3pzqnkz5cvxyhjcfhc/bafkreiesz5jfnvdgdmx5si6td7mtfw7bocuyqar7jmubhbsgxoaad3krfy",
            "fullsize": "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:e4wcdw3pzqnkz5cvxyhjcfhc/bafkreiesz5jfnvdgdmx5si6td7mtfw7bocuyqar7jmubhbsgxoaad3krfy",
        }
    ],
    "$type": "app.bsky.embed.images#view"
}
```

## Summary

Fix Bluesky image filename generation when CDN fullsize URLs no longer include an `@` extension suffix.

- Build a blob-CID-to-MIME-type map from record.embed.images.
- Extract the blob CID from each view image URL and use it to resolve the matching MIME type.
- Derive the file extension with `mimetypes.guess_extension()` instead of parsing it from the URL.
- Raise `NazurinError` for invalid image metadata, unknown blob IDs, or unsupported MIME types.
- Update the Bluesky API documentation links.
- Matching on the blob CID avoids relying on `record.embed.images` and `embed.images` sharing the same order.